### PR TITLE
feat: drop assistant on Ctrl+C

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -713,6 +713,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "sha2",
+ "signal-hook",
  "tar",
  "tokio",
  "toml",
@@ -1074,6 +1075,25 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest",
+]
+
+[[package]]
+name = "signal-hook"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8621587d4798caf8eb44879d42e56b9a93ea5dcd315a6487c357130095b62801"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/maa-cli/Cargo.toml
+++ b/maa-cli/Cargo.toml
@@ -28,6 +28,7 @@ zip = { version = "0.6.6", default-features = false, features = ["deflate"] }
 semver = { version = "1.0.18", features = ["serde"] }
 sha2 = "0.10.7"
 digest = "0.10.7"
+signal-hook = "0.3.17"
 
 [dependencies.chrono]
 version = "0.4.26"


### PR DESCRIPTION
之前收到终止信号的时候不会 drop 局部变量, 这样如果不调用 `AsstDestroy` 而终止进程可能出一些问题比如 coredump, 甚至生成奇奇怪怪的文件 (MaaAssistantArknights/MaaAssistantArknights#5255).
所以加了个处理信号的东西

`signal-hook` 声称 Windows 下也能用, 这个我没测试过.
~~`tokio` 似乎也有处理 Ctrl+C 的东西不过要加一堆异步的玩意, 还是算了~~