### PR TITLE
feat: add `core` field to CLI configuration

### DIFF
--- a/maa-cli/src/config/cli.rs
+++ b/maa-cli/src/config/cli.rs
@@ -6,12 +6,67 @@ use serde::Deserialize;
 #[cfg_attr(test, derive(Debug, PartialEq))]
 #[derive(Deserialize, Default)]
 pub struct CLIConfig {
-    /// MaaCore channel
+    /// DEPRECATED: Remove in the next breaking change
     #[serde(default)]
-    pub channel: Channel,
+    pub channel: Option<Channel>,
+    /// MaaCore configuration
+    #[serde(default)]
+    pub core: CoreConfig,
+}
+
+#[cfg_attr(test, derive(Debug, PartialEq))]
+#[derive(Deserialize, Default)]
+pub struct CoreConfig {
+    #[serde(default)]
+    channel: Channel,
+    #[serde(default)]
+    components: CoreComponents,
+}
+
+#[cfg_attr(test, derive(Debug, PartialEq))]
+#[derive(Deserialize)]
+pub struct CoreComponents {
+    #[serde(default = "return_true")]
+    resource: bool,
+}
+
+fn return_true() -> bool {
+    true
+}
+
+impl Default for CoreComponents {
+    fn default() -> Self {
+        CoreComponents {
+            resource: return_true(),
+        }
+    }
 }
 
 impl super::FromFile for CLIConfig {}
+
+impl CLIConfig {
+    pub fn channel(&self) -> Channel {
+        if let Some(channel) = self.channel {
+            println!(
+                "\x1b[33mWARNING\x1b[0m: \
+                The `channel` field in the CLI configuration is deprecated \
+                and will be removed in the next breaking change. \
+                Please use the `core.channel` field instead."
+            );
+            channel
+        } else {
+            println!(
+                "OK: Using `core.channel` field in the CLI configuration: {}",
+                self.core.channel
+            );
+            self.core.channel
+        }
+    }
+
+    pub fn resource(&self) -> bool {
+        self.core.components.resource
+    }
+}
 
 #[cfg(test)]
 mod tests {
@@ -21,6 +76,27 @@ mod tests {
     fn deserialize_example() {
         let config: CLIConfig = toml::from_str(
             r#"
+            [core]
+            channel = "beta"
+            [core.components]
+            resource = false
+            "#,
+        )
+        .unwrap();
+        assert_eq!(
+            config,
+            CLIConfig {
+                channel: None,
+                core: CoreConfig {
+                    channel: Channel::Beta,
+                    components: CoreComponents { resource: false }
+                }
+            }
+        );
+
+        let config: CLIConfig = toml::from_str(
+            r#"
+            [core]
             channel = "beta"
             "#,
         )
@@ -28,7 +104,11 @@ mod tests {
         assert_eq!(
             config,
             CLIConfig {
-                channel: Channel::Beta
+                channel: None,
+                core: CoreConfig {
+                    channel: Channel::Beta,
+                    components: CoreComponents { resource: true }
+                }
             }
         );
     }
@@ -39,8 +119,33 @@ mod tests {
         assert_eq!(
             config,
             CLIConfig {
-                channel: Channel::default(),
+                channel: None,
+                core: CoreConfig {
+                    channel: Channel::Stable,
+                    components: CoreComponents { resource: true }
+                }
             }
         );
+    }
+
+    #[test]
+    fn get_channel() {
+        let config = CLIConfig {
+            channel: Some(Channel::Beta),
+            core: CoreConfig {
+                channel: Channel::Stable,
+                components: CoreComponents { resource: true },
+            },
+        };
+        assert_eq!(config.channel(), Channel::Beta);
+
+        let config = CLIConfig {
+            channel: None,
+            core: CoreConfig {
+                channel: Channel::Stable,
+                components: CoreComponents { resource: true },
+            },
+        };
+        assert_eq!(config.channel(), Channel::Stable);
     }
 }

--- a/maa-cli/src/main.rs
+++ b/maa-cli/src/main.rs
@@ -277,7 +277,8 @@ fn main() -> Result<()> {
         } => {
             let cli_config =
                 CLIConfig::find_file(&proj_dirs.config().join("cli")).unwrap_or_default();
-            let channel = channel.unwrap_or(cli_config.channel);
+            let channel = channel.unwrap_or_else(|| cli_config.channel());
+            let no_resource = no_resource || !cli_config.resource();
             MaaCore::new(channel).install(&proj_dirs, force, no_resource, test_time)?;
         }
         CLI::Update {
@@ -287,7 +288,8 @@ fn main() -> Result<()> {
         } => {
             let cli_config =
                 CLIConfig::find_file(&proj_dirs.config().join("cli")).unwrap_or_default();
-            let channel = channel.unwrap_or(cli_config.channel);
+            let channel = channel.unwrap_or_else(|| cli_config.channel());
+            let no_resource = no_resource || !cli_config.resource();
             MaaCore::new(channel).update(&proj_dirs, no_resource, test_time)?;
         }
         CLI::SelfCommand(self_command) => match self_command {


### PR DESCRIPTION
This commit adds a `core` field to the CLI configuration. This field contains the channel to update the MaaCore and the components to install.
The `channel` field is deprecated and will be removed in the future.