### PR TITLE
feat: use `is_dir` instead of `exists()`

### DIFF
--- a/maa-cli/src/config/mod.rs
+++ b/maa-cli/src/config/mod.rs
@@ -55,7 +55,7 @@ const SUPPORTED_EXTENSION: [&str; 4] = ["json", "yaml", "yml", "toml"];
 
 pub trait FromFile: Sized + serde::de::DeserializeOwned {
     fn from_file(path: &Path) -> Result<Self, Error> {
-        if !path.exists() {
+        if !path.is_file() {
             return Err(Error::FileNotFound(path.to_str().unwrap().to_string()));
         }
         let filetype = path.extension().ok_or(Error::UnknownFiletype)?;
@@ -85,7 +85,7 @@ pub trait FindFile: FromFile {
     fn find_file(path: &Path) -> Result<Self, Error> {
         for filetype in SUPPORTED_EXTENSION.iter() {
             let path = path.with_extension(filetype);
-            if path.exists() {
+            if path.is_file() {
                 return Self::from_file(&path);
             }
         }

--- a/maa-cli/src/dirs.rs
+++ b/maa-cli/src/dirs.rs
@@ -124,7 +124,7 @@ impl Ensure for &Path {
     type Error = std::io::Error;
 
     fn ensure(self) -> Result<Self, Self::Error> {
-        if !self.exists() {
+        if !self.is_dir() {
             if let Some(parent) = self.parent() {
                 parent.ensure()?;
             }

--- a/maa-cli/src/installer/maa_cli.rs
+++ b/maa-cli/src/installer/maa_cli.rs
@@ -140,7 +140,7 @@ impl Asset {
         let path = dir.join(&self.name);
         let size = self.size;
 
-        if path.exists() {
+        if path.is_file() {
             let file_size = path.metadata()?.len();
             if file_size == size {
                 println!("Found existing file: {}", path.display());

--- a/maa-cli/src/installer/maa_core.rs
+++ b/maa-cli/src/installer/maa_core.rs
@@ -283,18 +283,18 @@ impl Asset {
 
 pub fn find_lib_dir(dirs: &Dirs) -> Option<PathBuf> {
     let lib_dir = dirs.library();
-    if lib_dir.join(MAA_CORE_NAME).exists() {
+    if lib_dir.join(MAA_CORE_NAME).is_file() {
         return Some(lib_dir.to_path_buf());
     }
 
     if let Ok(path) = std::env::current_exe() {
         let exe_dir = path.parent().unwrap();
-        if exe_dir.join(MAA_CORE_NAME).exists() {
+        if exe_dir.join(MAA_CORE_NAME).is_file() {
             return Some(exe_dir.to_path_buf());
         }
         if let Some(dir) = exe_dir.parent() {
             let lib_dir = dir.join("lib");
-            if lib_dir.join(MAA_CORE_NAME).exists() {
+            if lib_dir.join(MAA_CORE_NAME).is_file() {
                 return Some(lib_dir);
             }
         }
@@ -310,19 +310,19 @@ pub fn find_maa_core(dirs: &Dirs) -> Option<PathBuf> {
 
 pub fn find_resource(dirs: &Dirs) -> Option<PathBuf> {
     let resource_dir = dirs.resource();
-    if resource_dir.exists() {
+    if resource_dir.is_dir() {
         return Some(resource_dir.to_path_buf());
     }
 
     if let Ok(path) = std::env::current_exe() {
         let exe_dir = path.parent().unwrap();
         let resource_dir = exe_dir.join("resource");
-        if resource_dir.exists() {
+        if resource_dir.is_dir() {
             return Some(resource_dir);
         }
         if let Some(dir) = exe_dir.parent() {
             let resource_dir = dir.join("share").join("maa").join("resource");
-            if resource_dir.exists() {
+            if resource_dir.is_dir() {
                 return Some(resource_dir);
             }
         }

--- a/maa-cli/src/main.rs
+++ b/maa-cli/src/main.rs
@@ -340,7 +340,7 @@ fn main() -> Result<()> {
         } => run::run(&proj_dirs, task, addr, user_resource, verbose, quiet)?,
         CLI::List => {
             let task_dir = proj_dirs.config().join("tasks");
-            if !task_dir.exists() {
+            if !task_dir.is_dir() {
                 println!("No tasks found");
             } else {
                 for entry in task_dir.read_dir()? {

--- a/maa-cli/src/run/mod.rs
+++ b/maa-cli/src/run/mod.rs
@@ -47,7 +47,7 @@ pub fn run(
 
     /*--------------------- Load Config Files ---------------------*/
     let config_dir = dirs.config();
-    if !config_dir.exists() {
+    if !config_dir.is_dir() {
         bail!("Config directory not exists!");
     }
     debug!("Config directory:", config_dir.display());
@@ -244,7 +244,7 @@ pub fn run(
     }
 
     if user_resource {
-        if config_dir.join("resource").exists() {
+        if config_dir.join("resource").is_dir() {
             debug!("Loading user resource:", config_dir.display());
             Assistant::load_resource(config_dir).context("Failed to load user resource!")?;
         } else {


### PR DESCRIPTION
另外我写了一个 PKGBUILD 方便安装, [类似于这个](https://github.com/horror-proton/PKGBUILDs/blob/master/maa-cli-git/PKGBUILD) , 我之后可能会传到 [aur](https://aur.archlinux.org/) 上.

(如果你恰好比较熟悉基于 Arch 的发行版并会维护这个 aur 包的话应该让你来传 (x

因为我给 maa core 打的包放在 `/usr/share/maa-assistant-arknights` 里面, 所以这里可能出现一个无效的符号连接需要用 `is_dir` 判断