### PR TITLE
feat:  add a feature `self` to disable self update by disable it

### DIFF
--- a/maa-cli/Cargo.toml
+++ b/maa-cli/Cargo.toml
@@ -5,6 +5,10 @@ version = "0.3.8"
 edition = "2021"
 license.workspace = true
 
+[features]
+default = ["self"]
+self = []
+
 [[bin]]
 name = "maa"
 path = "src/main.rs"

--- a/maa-cli/src/installer/mod.rs
+++ b/maa-cli/src/installer/mod.rs
@@ -1,4 +1,5 @@
 mod download;
 mod extract;
+#[cfg(feature = "self")]
 pub mod maa_cli;
 pub mod maa_core;

--- a/maa-cli/src/main.rs
+++ b/maa-cli/src/main.rs
@@ -5,10 +5,9 @@ mod log;
 mod run;
 
 use crate::config::{cli::CLIConfig, FindFile};
-use crate::installer::{
-    maa_cli,
-    maa_core::{self, Channel, MaaCore},
-};
+#[cfg(feature = "self")]
+use crate::installer::maa_cli;
+use crate::installer::maa_core::{self, Channel, MaaCore};
 
 use anyhow::Result;
 use clap::{CommandFactory, Parser, Subcommand, ValueEnum};
@@ -132,6 +131,7 @@ enum CLI {
     /// This command is used to manage maa-cli self and maa-run.
     /// Note: If you want to install or update maa-core and resource,
     /// please use `maa-cli install` or `maa-cli update` instead.
+    #[cfg(feature = "self")]
     #[command(subcommand, name = "self")]
     SelfCommand(SelfCommand),
     /// Print path of maa directories
@@ -302,6 +302,7 @@ fn main() -> Result<()> {
             let no_resource = no_resource || !cli_config.resource();
             MaaCore::new(channel).update(&proj_dirs, no_resource, test_time)?;
         }
+        #[cfg(feature = "self")]
         CLI::SelfCommand(self_command) => match self_command {
             SelfCommand::Update => {
                 maa_cli::update(&proj_dirs)?;


### PR DESCRIPTION
If `maa-cli` is installed by some package manager like `brew`, self update is not needed and not encouraged.