### PR TITLE
Add workflow to update aur repo automatically

### DIFF
--- a/.github/workflows/arch-package.yml
+++ b/.github/workflows/arch-package.yml
@@ -1,0 +1,58 @@
+name: arch-package
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container:
+      image: archlinux:base-devel
+
+    steps:
+    - name: Upgrade system
+      run: |
+        pacman -Syu --needed --noconfirm git openssh pacman-contrib namcap
+        sed -i '/E_ROOT/d' /usr/bin/makepkg
+
+    - name: Setup ssh
+      run: |
+        mkdir -vpm700 ~root/.ssh && cd "$_"
+        install -m700 <(echo '${{ secrets.AUR_SSH_PRIVATE_KEY }}') id_rsa
+        install -m700 <(ssh-keyscan -H aur.archlinux.org) known_hosts
+
+    - name: Fetch from aur
+      run: |
+        git clone ssh://aur@aur.archlinux.org/maa-cli.git
+
+    - name: Patch pkgver
+      run: |
+        cd maa-cli
+        ref=${{ github.ref }}
+        sed -i "/^pkgver=/cpkgver=${ref#refs/tags/v}" PKGBUILD
+        sed -i "/^pkgrel=/cpkgrel=1" PKGBUILD
+
+    - name: Makepkg
+      run: |
+        cd maa-cli
+        updpkgsums
+        makepkg -s --noconfirm
+        namcap *.pkg.tar.zst
+        makepkg --printsrcinfo > .SRCINFO
+
+    - name: Commit changes
+      run: |
+        cd maa-cli
+        git config user.name "github-actions[bot]"
+        git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+        git add .
+
+        echo '```diff' >> $GITHUB_STEP_SUMMARY
+        git diff --staged >> $GITHUB_STEP_SUMMARY
+        echo '```' >> $GITHUB_STEP_SUMMARY
+
+        git commit -m "github-actions[bot]: Upgrade to ${{ github.ref_name }}"
+        git push origin --verbose

--- a/.github/workflows/publish-aur.yml
+++ b/.github/workflows/publish-aur.yml
@@ -1,12 +1,26 @@
-name: arch-package
+name: Publish AUR Package
 
 on:
-  push:
-    tags:
-      - 'v*'
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      pkgver:
+        required: false
+        type: string
+      pkgrel:
+        default: 1
+        required: false
+        type: number
+      dryrun:
+        description: 'Do not push changes to aur'
+        default: true
+        required: true
+        type: boolean
 
 jobs:
-  build:
+  publish:
+    name: Publish
     runs-on: ubuntu-latest
     container:
       image: archlinux:base-devel
@@ -30,9 +44,9 @@ jobs:
     - name: Patch pkgver
       run: |
         cd maa-cli
-        ref=${{ github.ref }}
+        ref=${{ inputs.pkgver || github.ref }}
         sed -i "/^pkgver=/cpkgver=${ref#refs/tags/v}" PKGBUILD
-        sed -i "/^pkgrel=/cpkgrel=1" PKGBUILD
+        sed -i "/^pkgrel=/cpkgrel=${{ inputs.pkgrel || 1 }}" PKGBUILD
 
     - name: Makepkg
       run: |
@@ -54,5 +68,10 @@ jobs:
         git diff --staged >> $GITHUB_STEP_SUMMARY
         echo '```' >> $GITHUB_STEP_SUMMARY
 
-        git commit -m "github-actions[bot]: Upgrade to ${{ github.ref_name }}"
-        git push origin --verbose
+        git commit -m "github-actions[bot]: Upgrade to ${{ inputs.pkgver || github.ref_name }}"
+        git push origin --verbose ${{ inputs.dryrun && '--dry-run' || '' }}
+
+    - uses: actions/upload-artifact@v3
+      with:
+        name: package
+        path: maa-cli/*.pkg.tar.zst


### PR DESCRIPTION
This workflow would build and push new version number to `aur.archlinux.org/maa-cli.git` when a new tag was pushed.

Sed scripts were copied from [arch_package.yml](https://github.com/hykilpikonna/hyfetch/blob/master/.github/workflows/arch_package.yml)