### PR TITLE
ci: call `publish-*` workflows after release

### DIFF
--- a/.github/workflows/publish-aur.yml
+++ b/.github/workflows/publish-aur.yml
@@ -3,17 +3,38 @@ name: Publish AUR Package
 on:
   release:
     types: [published]
-  workflow_dispatch:
+  workflow_call:
     inputs:
       pkgver:
+        description: Package version
         required: false
         type: string
       pkgrel:
+        description: Package release number
         default: 1
         required: false
         type: number
       dryrun:
-        description: 'Do not push changes to aur'
+        description: Do not push changes to AUR
+        required: true
+        type: boolean
+    secrets:
+      AUR_SSH_PRIVATE_KEY:
+        description: SSH private key for AUR
+        required: true
+  workflow_dispatch:
+    inputs:
+      pkgver:
+        description: Package version
+        required: false
+        type: string
+      pkgrel:
+        description: Package release number
+        default: 1
+        required: false
+        type: number
+      dryrun:
+        description: Do not push changes to AUR
         default: true
         required: true
         type: boolean
@@ -37,7 +58,7 @@ jobs:
         install -m700 <(echo '${{ secrets.AUR_SSH_PRIVATE_KEY }}') id_rsa
         install -m700 <(ssh-keyscan -H aur.archlinux.org) known_hosts
 
-    - name: Fetch from aur
+    - name: Fetch from AUR
       run: |
         git clone ssh://aur@aur.archlinux.org/maa-cli.git
 

--- a/.github/workflows/publish-homebrew.yml
+++ b/.github/workflows/publish-homebrew.yml
@@ -11,7 +11,6 @@ on:
         type: string
       dryrun:
         description: Do not push changes to Homebrew
-        default: true
         required: true
         type: boolean
     secrets:
@@ -51,11 +50,11 @@ jobs:
           tag: ${{ inputs.version || github.ref }}
           no_fork: true
           force: false
-          dryrun: $${ inputs.dryrun || false }
+          dryrun: ${{ github.event_name != 'release' || inputs.dryrun }}
 
   formula:
     name: Formula
-    if: ${{ !inputs.dryrun || true }}
+    if: ${{ github.event_name == 'release' || !inputs.dryrun }}
     runs-on: macos-latest
     steps:
       - name: Update Homebrew Formula
@@ -64,6 +63,6 @@ jobs:
           token: ${{secrets.MAA_HOMEBREW_BUMP_PR}}
           tap: MaaAssistantArknights/homebrew-tap
           formula: maa-cli
-          tag: v${{ needs.meta.outputs.version }}
+          tag: ${{ inputs.version || github.ref }}
           no_fork: true
           force: false

--- a/.github/workflows/publish-homebrew.yml
+++ b/.github/workflows/publish-homebrew.yml
@@ -14,6 +14,10 @@ on:
         default: true
         required: true
         type: boolean
+    secrets:
+      MAA_HOMEBREW_BUMP_PR:
+        description: GitHub PAT for creating PR
+        required: true
   workflow_dispatch:
     inputs:
       version:
@@ -51,7 +55,7 @@ jobs:
 
   formula:
     name: Formula
-    if: ${{ inputs.dryrun || false }}
+    if: ${{ !inputs.dryrun || true }}
     runs-on: macos-latest
     steps:
       - name: Update Homebrew Formula

--- a/.github/workflows/publish-homebrew.yml
+++ b/.github/workflows/publish-homebrew.yml
@@ -3,6 +3,28 @@ name: Publish Homebrew
 on:
   release:
     types: [published]
+  workflow_call:
+    inputs:
+      version:
+        description: Package version
+        required: false
+        type: string
+      dryrun:
+        description: Do not push changes to Homebrew
+        default: true
+        required: true
+        type: boolean
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Package version
+        required: false
+        type: string
+      dryrun:
+        description: Do not push changes to Homebrew
+        default: true
+        required: true
+        type: boolean
 
 defaults:
   run:
@@ -12,32 +34,9 @@ permissions:
   contents: read
 
 jobs:
-  meta:
-    runs-on: ubuntu-latest
-    outputs:
-      version: ${{ steps.version.outputs.version }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Get Version
-        id: version
-        run: |
-          CARGO_VERSION=$(yq -oy ".package.version" maa-cli/Cargo.toml)
-          # check if version is equal to tag if not PR
-          if [ "$GITHUB_EVENT_NAME" != "pull_request" ]; then
-            REF=${{ github.ref }}
-            REF_VERSION=${REF#refs/tags/v}
-            if [ "$REF_VERSION" != "$CARGO_VERSION" ]; then
-              echo "Version mismatch: $REF_VERSION != $CARGO_VERSION"
-            fi
-          fi
-          echo "Version: $CARGO_VERSION"
-          echo "version=$CARGO_VERSION" >> $GITHUB_OUTPUT
-
-  bump-cask:
-    name: Bump Cask and Open PR
+  cask:
+    name: Cask
     runs-on: macos-latest
-    needs: [meta]
     steps:
       - name: Update Homebrew Cask
         uses: wangl-cc/action-homebrew-bump-cask@master
@@ -45,14 +44,15 @@ jobs:
           token: ${{secrets.MAA_HOMEBREW_BUMP_PR}}
           tap: MaaAssistantArknights/homebrew-tap
           cask: maa-cli-bin
-          tag: v${{ needs.meta.outputs.version }}
+          tag: ${{ inputs.version || github.ref }}
           no_fork: true
           force: false
+          dryrun: $${ inputs.dryrun || false }
 
-  bump-formula:
-    name: Bump Formula and Open PR
+  formula:
+    name: Formula
+    if: ${{ inputs.dryrun || false }}
     runs-on: macos-latest
-    needs: [meta]
     steps:
       - name: Update Homebrew Formula
         uses: dawidd6/action-homebrew-bump-formula@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,10 +44,6 @@ jobs:
             dryrun=true
           fi
           echo "dryrun=$dryrun" >> $GITHUB_OUTPUT
-      - name: If Dryrun
-        if: ${{ fromJson(steps.dryrun.outputs.dryrun) }}
-        run: |
-          echo "Dryrun"
       - name: Get Version
         id: version
         run: |
@@ -205,3 +201,21 @@ jobs:
           echo '```' >> $GITHUB_STEP_SUMMARY
           git commit version.json -m "Update version.json"
           git push --verbose ${{ fromJson(needs.meta.outputs.dryrun) && '--dry-run' || ''}}
+
+  publish-homebrew:
+    needs: [meta, release]
+    name: Publish Homebrew Formula and Cask
+    uses: ./.github/workflows/publish-homebrew.yml
+    with:
+      version: v${{ needs.meta.outputs.version }}
+      dryrun: ${{ fromJson(needs.meta.outputs.dryrun) }}
+
+  publish-aur:
+    needs: [meta, release]
+    name: Publish AUR Package
+    uses: ./.github/workflows/publish-aur.yml
+    with:
+      pkgver: ${{ needs.meta.outputs.version }}
+      dryrun: ${{ fromJson(needs.meta.outputs.dryrun) }}
+    secrets:
+      AUR_SSH_PRIVATE_KEY: ${{ secrets.AUR_SSH_PRIVATE_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -204,18 +204,21 @@ jobs:
 
   publish-homebrew:
     needs: [meta, release]
-    name: Publish Homebrew Formula and Cask
+    name: Publish Homebrew
     uses: ./.github/workflows/publish-homebrew.yml
     with:
       version: v${{ needs.meta.outputs.version }}
       dryrun: ${{ fromJson(needs.meta.outputs.dryrun) }}
+    secrets:
+      MAA_HOMEBREW_BUMP_PR: ${{ secrets.MAA_HOMEBREW_BUMP_PR }}
 
   publish-aur:
     needs: [meta, release]
+    if: ${{ !fromJson(needs.meta.outputs.dryrun) }}
     name: Publish AUR Package
     uses: ./.github/workflows/publish-aur.yml
     with:
       pkgver: ${{ needs.meta.outputs.version }}
-      dryrun: ${{ fromJson(needs.meta.outputs.dryrun) }}
+      dryrun: false
     secrets:
       AUR_SSH_PRIVATE_KEY: ${{ secrets.AUR_SSH_PRIVATE_KEY }}


### PR DESCRIPTION
Release created by ci will [not trigger other workflows run](https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow). So we need to call workflow in release workflow. 