### PR TITLE
fix: canonicalize returned path of `current_exe`

### DIFF
--- a/maa-cli/src/installer/maa_cli.rs
+++ b/maa-cli/src/installer/maa_cli.rs
@@ -1,16 +1,16 @@
-// This file is used to download and extract prebuilt packages of maa-cli.
-
-use crate::dirs::{Dirs, Ensure};
-
 use super::{
     download::{download, Checker},
     extract::Archive,
 };
 
-use std::env::{consts::EXE_SUFFIX, current_exe};
-use std::{env::var_os, path::Path};
+use crate::dirs::{Dirs, Ensure};
 
-use anyhow::{bail, Context, Ok, Result};
+use std::{
+    env::{consts::EXE_SUFFIX, var_os},
+    path::{Path, PathBuf},
+};
+
+use anyhow::{bail, Context, Result};
 use semver::Version;
 use serde::Deserialize;
 use tokio::runtime::Runtime;
@@ -55,6 +55,10 @@ pub fn update(dirs: &Dirs) -> Result<()> {
     })?;
 
     Ok(())
+}
+
+pub fn current_exe() -> std::io::Result<PathBuf> {
+    std::env::current_exe()?.canonicalize()
 }
 
 fn get_metadata() -> Result<VersionJSON> {
@@ -144,7 +148,7 @@ impl Asset {
             let file_size = path.metadata()?.len();
             if file_size == size {
                 println!("Found existing file: {}", path.display());
-                return Ok(Archive::try_from(path)?);
+                return Archive::try_from(path);
             }
         }
 
@@ -162,7 +166,7 @@ impl Asset {
             ))
             .context("Failed to download maa-cli")?;
 
-        Ok(Archive::try_from(path)?)
+        Archive::try_from(path)
     }
 }
 

--- a/maa-cli/src/installer/maa_core.rs
+++ b/maa-cli/src/installer/maa_core.rs
@@ -1,15 +1,20 @@
 // This file is used to download and extract prebuilt packages of maa-core.
 
-use super::download::download_mirrors;
-use super::extract::Archive;
+use super::{download::download_mirrors, extract::Archive, maa_cli::current_exe};
 
-use crate::dirs::{Dirs, Ensure};
-use crate::run;
+use crate::{
+    dirs::{Dirs, Ensure},
+    run,
+};
 
-use std::env::consts::{DLL_PREFIX, DLL_SUFFIX};
-use std::env::var_os;
-use std::path::{Component, Path, PathBuf};
-use std::time::Duration;
+use std::{
+    env::{
+        consts::{DLL_PREFIX, DLL_SUFFIX},
+        var_os,
+    },
+    path::{Component, Path, PathBuf},
+    time::Duration,
+};
 
 use anyhow::{anyhow, bail, Context, Result};
 use clap::ValueEnum;
@@ -287,7 +292,7 @@ pub fn find_lib_dir(dirs: &Dirs) -> Option<PathBuf> {
         return Some(lib_dir.to_path_buf());
     }
 
-    if let Ok(path) = std::env::current_exe() {
+    if let Ok(path) = current_exe() {
         let exe_dir = path.parent().unwrap();
         if exe_dir.join(MAA_CORE_NAME).exists() {
             return Some(exe_dir.to_path_buf());
@@ -314,7 +319,7 @@ pub fn find_resource(dirs: &Dirs) -> Option<PathBuf> {
         return Some(resource_dir.to_path_buf());
     }
 
-    if let Ok(path) = std::env::current_exe() {
+    if let Ok(path) = current_exe() {
         let exe_dir = path.parent().unwrap();
         let resource_dir = exe_dir.join("resource");
         if resource_dir.exists() {


### PR DESCRIPTION
If the current executable is a symlink, `current_exe` returns the path of the symlink, not the path of the target in some platforms. This commit fixes it by calling `canonicalize` on the returned path.

See #67