### PR TITLE
fix: `user_resource` should be a bool instead of an option 

### DIFF
--- a/maa-cli/src/main.rs
+++ b/maa-cli/src/main.rs
@@ -215,7 +215,7 @@ enum SubCommand {
         /// if there are some resources with the same name.
         /// Use at your own risk!
         #[clap(long, verbatim_doc_comment)]
-        user_resource: Option<bool>,
+        user_resource: bool,
         /// Run tasks in batch mode
         ///
         /// If there are some input parameters in the task file,

--- a/maa-cli/src/run/mod.rs
+++ b/maa-cli/src/run/mod.rs
@@ -27,7 +27,7 @@ pub fn run(
     dirs: &Dirs,
     task: String,
     addr: Option<String>,
-    user_resource: Option<bool>,
+    user_resource: bool,
     batch: bool,
 ) -> Result<()> {
     /*------------------------ Load MaaCore ------------------------*/
@@ -217,7 +217,7 @@ pub fn run(
     }
 
     // User resource in config directory
-    if user_resource.unwrap_or(asst_config.user_resource) {
+    if user_resource || asst_config.user_resource {
         if config_dir.join("resource").exists() {
             debug!("Loading user resource:", config_dir.display());
             Assistant::load_resource(config_dir).context("Failed to load user resource!")?;


### PR DESCRIPTION
If the type of `user_resource` is `Option<bool>`, it requires the user to specify the value of `user_resource` when running the command `maa run`.