### PR TITLE
fix: failed to exit on windows

### DIFF
--- a/maa-cli/src/run/mod.rs
+++ b/maa-cli/src/run/mod.rs
@@ -81,8 +81,9 @@ pub fn run(
         Connection::PlayTools { address, config } => {
             playtools = true;
             let address = addr.unwrap_or(address);
-            debug!("Setting address to", &address);
-            debug!("Setting config to", &config);
+            debug!("Connect to game via PlayTools");
+            debug!("address:", &address);
+            debug!("config:", &config);
             (String::new(), address, config)
         }
     };
@@ -285,6 +286,7 @@ pub fn run(
     let assistant = Assistant::new(Some(callback), None);
 
     // Set instance options
+    debug!("Setting instance options...");
     if let Some(v) = instance_options.touch_mode {
         assistant
             .set_instance_option(2, v)
@@ -333,6 +335,7 @@ pub fn run(
     }
 
     // TODO: Better ways to restore signal handlers?
+    debug!("Restoring signal handlers...");
     stop_bool.store(true, std::sync::atomic::Ordering::Relaxed);
 
     Ok(())

--- a/maa-cli/src/run/mod.rs
+++ b/maa-cli/src/run/mod.rs
@@ -81,9 +81,8 @@ pub fn run(
         Connection::PlayTools { address, config } => {
             playtools = true;
             let address = addr.unwrap_or(address);
-            debug!("Connect to game via PlayTools");
-            debug!("address:", &address);
-            debug!("config:", &config);
+            debug!("Setting address to", &address);
+            debug!("Setting config to", &config);
             (String::new(), address, config)
         }
     };
@@ -286,7 +285,6 @@ pub fn run(
     let assistant = Assistant::new(Some(callback), None);
 
     // Set instance options
-    debug!("Setting instance options...");
     if let Some(v) = instance_options.touch_mode {
         assistant
             .set_instance_option(2, v)
@@ -335,7 +333,6 @@ pub fn run(
     }
 
     // TODO: Better ways to restore signal handlers?
-    debug!("Restoring signal handlers...");
     stop_bool.store(true, std::sync::atomic::Ordering::Relaxed);
 
     Ok(())


### PR DESCRIPTION
Try run with `MaaCore` failed to exit in CI.
See: https://github.com/MaaAssistantArknights/maa-cli/actions/runs/6516174359/job/17699423949

It seems caused by `stop_bool.store(true, std::sync::atomic::Ordering::Relaxed)`,
see https://github.com/MaaAssistantArknights/maa-cli/actions/runs/6516380388/job/17699850335?pr=79#step:9:41.

Solution: We disable signal handling on windows as a temporary fix. But we can't remove `signal_hook` from dependencies on windows now, because of lifetime of variable in conditional block.