### PR TITLE
feat: search both origin and canonicalized directory of `current_exe`

### DIFF
--- a/maa-cli/src/installer/maa_cli.rs
+++ b/maa-cli/src/installer/maa_cli.rs
@@ -1,17 +1,17 @@
 use super::{
     download::{download, Checker},
     extract::Archive,
-    maa_core::current_exe,
 };
 
 use crate::dirs::{Dirs, Ensure};
 
 use std::{
-    env::{consts::EXE_SUFFIX, var_os},
+    env::{consts::EXE_SUFFIX, current_exe, var_os},
     path::Path,
 };
 
 use anyhow::{bail, Context, Result};
+use dunce::canonicalize;
 use semver::Version;
 use serde::Deserialize;
 use tokio::runtime::Runtime;
@@ -44,7 +44,7 @@ pub fn update(dirs: &Dirs) -> Result<()> {
     );
 
     let bin_name = name();
-    let bin_path = current_exe()?;
+    let bin_path = canonicalize(current_exe()?)?;
     let cache_dir = dirs.cache().ensure()?;
 
     asset.download(cache_dir)?.extract(|path| {


### PR DESCRIPTION
In recent changes, we force `current_exe` to be canonicalized. However, for homebrew, `maa` is installed in separate directory, and linked to `/usr/local/bin/maa` or `/opt/homebrew/bin/maa`. To search library and resource also installed by homebrew, we need to search the origin directory of `current_exe`. So we search both origin and canonicalized directory of `current_exe`.