### PR TITLE
ci: generate release notes based on the last release

### DIFF
--- a/.github/scripts/parse_version.sh
+++ b/.github/scripts/parse_version.sh
@@ -76,12 +76,21 @@ version=${version:-$CARGO_PKG_VERSION}
 tag=${tag:-v$version}
 publish=${publish:-true}
 
+if [ "$channel" != "beta" ]; then
+  # both stable and alpha channel are compared to the last stable release
+  compare_base=$(yq -oy -r ".details.commit" version/stable.json)
+else
+  # beta channel is compared to the last beta release
+  compare_base=$(yq -oy -r ".details.commit" version/beta.json)
+fi
+
 echo "Release version $version with tag $tag to channel $channel (publish: $publish)"
 {
   echo "commit=$commit_sha"
   echo "channel=$channel"
   echo "version=$version"
   echo "tag=$tag"
+  echo "compare_base=$compare_base"
   echo "publish=$publish"
   echo "skip=false"
 } >> "$GITHUB_OUTPUT"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,6 +43,7 @@ jobs:
     outputs:
       version: ${{ steps.version.outputs.version }}
       tag: ${{ steps.version.outputs.tag }}
+      compare_base: ${{ steps.version.outputs.compare_base }}
       commit: ${{ steps.version.outputs.commit }}
       channel: ${{ steps.version.outputs.channel }}
       prerelease: ${{ steps.version.outputs.channel != 'stable' }}
@@ -77,7 +78,16 @@ jobs:
         uses: orhun/git-cliff-action@v2
         with:
           config: cliff.toml
-          args: -vv ${{ fromJson(needs.meta.outputs.prerelease) && '-u' || '-l' }}
+          args: -vv ${{ needs.meta.outputs.compare_base }}..HEAD
+      - name: Preview Release Notes
+        if: ${{ !fromJson(needs.meta.outputs.publish) }}
+        run: |
+          {
+            echo '```markdown'
+            echo "${{ steps.git_cliff.outputs.content }}"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
 
   build:
     name: Build
@@ -258,10 +268,10 @@ jobs:
           {
             echo "Commit changes to version.json"
             echo '```diff'
-            git diff *.json
+            git diff ./*.json
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"
-          git commit *.json -m "chore: bump version to v${{ needs.meta.outputs.version }}"
+          git commit ./*.json -m "chore: bump version to v${{ needs.meta.outputs.version }}"
           git push --verbose ${{ !fromJson(needs.meta.outputs.publish) && '--dry-run' || ''}}
 
   publish-homebrew:


### PR DESCRIPTION
The git-cliff action always compares the current HEAD to the last tag. However, we want to compare beta releases to the last beta release and stable releases to the last stable release.