### PR TITLE
ci: use tag pattern to filter out pre-releases

### DIFF
--- a/.github/scripts/parse_version.sh
+++ b/.github/scripts/parse_version.sh
@@ -76,21 +76,12 @@ version=${version:-$CARGO_PKG_VERSION}
 tag=${tag:-v$version}
 publish=${publish:-true}
 
-if [ "$channel" != "beta" ]; then
-  # both stable and alpha channel are compared to the last stable release
-  compare_base=$(yq -oy -r ".details.commit" version/stable.json)
-else
-  # beta channel is compared to the last beta release
-  compare_base=$(yq -oy -r ".details.commit" version/beta.json)
-fi
-
 echo "Release version $version with tag $tag to channel $channel (publish: $publish)"
 {
   echo "commit=$commit_sha"
   echo "channel=$channel"
   echo "version=$version"
   echo "tag=$tag"
-  echo "compare_base=$compare_base"
   echo "publish=$publish"
   echo "skip=false"
 } >> "$GITHUB_OUTPUT"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -197,9 +197,14 @@ jobs:
           path: version
       - name: Extract files, Generate checksums and Update version.json
         run: |
-          version_files=(
-            version/alpha.json
-          )
+          # When release channel is stable, update all channel version info
+          # When release channel is beta, update beta version info only
+          # (don't update alpha version info, because alpha version is nightly,
+          # once a beta version is installed, alpha version will be considered
+          # as outdated)
+          # When release channel is alpha, update alpha version info only
+          version_files=()
+          [ "$CHANNEL" != "beta" ] && version_files+=(version/alpha.json)
           [ "$CHANNEL" != "alpha" ] && version_files+=(version/beta.json)
           [ "$CHANNEL" == "stable" ] && version_files+=(version/stable.json)
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,6 @@ jobs:
     outputs:
       version: ${{ steps.version.outputs.version }}
       tag: ${{ steps.version.outputs.tag }}
-      compare_base: ${{ steps.version.outputs.compare_base }}
       commit: ${{ steps.version.outputs.commit }}
       channel: ${{ steps.version.outputs.channel }}
       prerelease: ${{ steps.version.outputs.channel != 'stable' }}
@@ -79,7 +78,9 @@ jobs:
         uses: orhun/git-cliff-action@v2
         with:
           config: cliff.toml
-          args: -vv ${{ needs.meta.outputs.compare_base }}..HEAD
+          # If the release is a prerelease, use unreleased commits
+          # otherwise use commits belonging to the last release
+          args: -vv ${{ fromJson(needs.meta.outputs.prerelease) && '-u' || '-l' }}
       - name: Preview Release Notes
         if: ${{ !fromJson(needs.meta.outputs.publish) }}
         run: |

--- a/cliff.toml
+++ b/cliff.toml
@@ -6,13 +6,14 @@ header = """
 # template for the changelog body
 # https://keats.github.io/tera/docs/#introduction
 body = """
-{% for group in ["Breaking Changes", "Features", "Bug Fixes", "Performance",
+{% for group in ["Features", "Bug Fixes", "Performance",
 "Refactor", "Documentation", "Testing", "Miscellaneous", "Security", "Revert"] -%}
     {% set grouped_commits = commits | filter(attribute="group", value=group) -%}
     {% if grouped_commits | length > 0 -%}
         ## {{ group }}\n
         {% for commit in grouped_commits -%}
-          - {{ commit.message | upper_first }}
+          - {% if commit.breaking %}**BREAKING**: {% endif -%}
+            {{ commit.message | upper_first }}
         {% endfor -%}
         {{ "" }}
     {% endif -%}
@@ -38,7 +39,6 @@ commit_preprocessors = [
 ]
 # regex for parsing and grouping commits
 commit_parsers = [
-  { breaking = true, group = "Breaking Changes" },
   { message = "^feat", group = "Features" },
   { message = "^fix", group = "Bug Fixes" },
   { message = "^perf", group = "Performance" },
@@ -48,28 +48,27 @@ commit_parsers = [
   { message = "^style", skip = true },
   { message = "^chore\\(release\\): prepare for", skip = true },
   { message = "^chore\\(deps\\)", skip = true },
-  { message = "^chore\\(pr\\)", skip = true },
-  { message = "^chore\\(pull\\)", skip = true },
-  { message = "^chore|ci", group = "Miscellaneous" },
+  { message = "^ci", skip = true },
+  { message = "^chore", group = "Miscellaneous" },
 
   { body = ".*security", group = "Security" },
   { message = "^[Rr]evert", group = "Revert" },
 
   { message = "^Bump", skip = true },
-]
+] # regex for parsing and grouping commits
 # protect breaking changes from being skipped due to matching a skipping commit_parser
 protect_breaking_commits = false
 # filter out the commits that are not matched by commit parsers
 filter_commits = false
 # glob pattern for matching git tags
-tag_pattern = "v[0-9]*"
+tag_pattern = "^v[0-9]+.[0-9]+.[0-9]+$"
 # regex for skipping tags
 # skip_tags = "v0.1.0-beta.1"
 # regex for ignoring tags
-ignore_tags = ""
+# ignore_tags = "v[0-9].[0-9].[0-9]-beta.*"
 # sort the tags topologically
 topo_order = false
 # sort the commits inside sections by oldest/newest order
-sort_commits = "newest"
+sort_commits = "oldest"
 # limit the number of commits included in the changelog.
 # limit_commits = 42


### PR DESCRIPTION
So far, we have been using the `compare_base` output from the `parse_version.sh` script to determine the range of commits to be included in the changelog. This not works well,
because the pre-release also splits the commits into multiple groups. For example, if the last stable release is `v0.1.0`, and last beta release is `v0.1.1-beta.1`, then the changelog from head will include all commits from `v0.1.0` to head, but they will be split into two groups: `v0.1.0..v0.1.1-beta.1` and `v0.1.1-beta.1..HEAD`. This is not what we want.

So instead of using `compare_base`, we use the `tag_pattern` to filter out pre-releases. This will ensure that the changelog compares to the last stable release, and they are grouped into a single group.