### PR TITLE
feat!: download native binaries instead of universal binaries on macOS

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -223,6 +223,8 @@ jobs:
             x86_64-unknown-linux-gnu
             aarch64-unknown-linux-gnu
             universal-apple-darwin
+            x86_64-apple-darwin
+            aarch64-apple-darwin
             x86_64-pc-windows-msvc
           )
 

--- a/maa-cli/src/installer/maa_cli.rs
+++ b/maa-cli/src/installer/maa_cli.rs
@@ -96,8 +96,10 @@ impl Details {
 
 #[derive(Deserialize)]
 struct Assets {
-    #[serde(rename = "universal-apple-darwin")]
-    universal_apple_darwin: Asset,
+    #[serde(rename = "x86_64-apple-darwin")]
+    x86_64_apple_darwin: Asset,
+    #[serde(rename = "aarch64-apple-darwin")]
+    aarch64_apple_darwin: Asset,
     #[serde(rename = "x86_64-unknown-linux-gnu")]
     x86_64_unknown_linux_gnu: Asset,
     #[serde(rename = "aarch64-unknown-linux-gnu")]
@@ -109,7 +111,11 @@ struct Assets {
 impl Assets {
     fn asset(&self) -> Result<&Asset> {
         match consts::OS {
-            "macos" => Ok(&self.universal_apple_darwin),
+            "macos" => match consts::ARCH {
+                "x86_64" => Ok(&self.x86_64_apple_darwin),
+                "aarch64" => Ok(&self.aarch64_apple_darwin),
+                _ => bail!("Unsupported architecture: {}", consts::ARCH),
+            },
             "linux" => match consts::ARCH {
                 "x86_64" => Ok(&self.x86_64_unknown_linux_gnu),
                 "aarch64" => Ok(&self.aarch64_unknown_linux_gnu),
@@ -156,7 +162,12 @@ mod tests {
     "details": {
         "tag": "v0.1.0",
         "assets": {
-            "universal-apple-darwin": {
+            "x86_64-apple-darwin": {
+                "name": "maa-cli.zip",
+                "size": 123456,
+                "sha256sum": "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
+            },
+            "aarch64-apple-darwin": {
                 "name": "maa-cli.zip",
                 "size": 123456,
                 "sha256sum": "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"

--- a/maa-cli/src/run/playcover.rs
+++ b/maa-cli/src/run/playcover.rs
@@ -42,7 +42,7 @@ impl<'n> PlayCoverApp<'n> {
             return Ok(());
         }
 
-        info!("Starting app: {}", self.name);
+        info!("Starting app:", self.name);
         std::process::Command::new("open")
             .arg("-a")
             .arg(self.name)


### PR DESCRIPTION
Currently, the build for `x86_64-apple-darwin` and `aarch64-apple-darwin` are not the same. The `aarch64` build with `vendored` openssl, while the `x86_64` build uses the system openssl.