### PR TITLE
fix!: ensure extra share name is a name instead of a path

### DIFF
--- a/maa-cli/src/dirs.rs
+++ b/maa-cli/src/dirs.rs
@@ -383,6 +383,7 @@ where
 /// # Panics
 ///
 /// Panics if the given str is a string containing path separator.
+#[allow(dead_code)]
 fn ensure_name(name: &str) -> &str {
     assert!(
         !name.contains(std::path::is_separator),


### PR DESCRIPTION
Fix #158 