### PR TITLE
ci: don't cache for jobs without coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,8 +107,6 @@ jobs:
         with:
           os: ${{ matrix.os }}
           arch: aarch64
-      - name: Setup Cache
-        uses: Swatinem/rust-cache@v2
       - name: Build
         run: |
           cargo build --package maa-cli --locked \
@@ -135,10 +133,6 @@ jobs:
         with:
           os: ${{ matrix.os }}
           arch: x86_64
-      - name: Setup Cache
-        uses: Swatinem/rust-cache@v2
-        with:
-          key: ${{ matrix.feature }}
       - name: Build
         run: |
           cargo build --package maa-cli --locked \


### PR DESCRIPTION
The most expensive part of the CI is the coverage job, so build jobs without coverage is much faster. Due to the storage limit of cache, we can't cache for all jobs, so we only cache for jobs with coverage.