### PR TITLE
chore: rename `as_string` to `as_str`

### DIFF
--- a/maa-cli/src/value/mod.rs
+++ b/maa-cli/src/value/mod.rs
@@ -211,7 +211,7 @@ impl MAAValue {
     }
 
     pub fn as_str(&self) -> Option<&str> {
-        self.as_primate().and_then(MAAPrimate::as_string)
+        self.as_primate().and_then(MAAPrimate::as_str)
     }
 
     pub fn merge_mut(&mut self, other: &Self) {

--- a/maa-cli/src/value/primate.rs
+++ b/maa-cli/src/value/primate.rs
@@ -33,7 +33,7 @@ impl MAAPrimate {
         }
     }
 
-    pub(super) fn as_string(&self) -> Option<&str> {
+    pub(super) fn as_str(&self) -> Option<&str> {
         match self {
             Self::String(v) => Some(v),
             _ => None,
@@ -144,21 +144,21 @@ mod tests {
         assert_eq!(MAAPrimate::Bool(true).as_bool(), Some(true));
         assert_eq!(MAAPrimate::Bool(true).as_int(), None);
         assert_eq!(MAAPrimate::Bool(true).as_float(), None);
-        assert_eq!(MAAPrimate::Bool(true).as_string(), None);
+        assert_eq!(MAAPrimate::Bool(true).as_str(), None);
 
         assert_eq!(MAAPrimate::Int(1).as_bool(), None);
         assert_eq!(MAAPrimate::Int(1).as_int(), Some(1));
         assert_eq!(MAAPrimate::Int(1).as_float(), None);
-        assert_eq!(MAAPrimate::Int(1).as_string(), None);
+        assert_eq!(MAAPrimate::Int(1).as_str(), None);
 
         assert_eq!(MAAPrimate::Float(1.0).as_bool(), None);
         assert_eq!(MAAPrimate::Float(1.0).as_int(), None);
         assert_eq!(MAAPrimate::Float(1.0).as_float(), Some(1.0));
-        assert_eq!(MAAPrimate::Float(1.0).as_string(), None);
+        assert_eq!(MAAPrimate::Float(1.0).as_str(), None);
 
         assert_eq!(MAAPrimate::String("".to_string()).as_bool(), None);
         assert_eq!(MAAPrimate::String("".to_string()).as_int(), None);
         assert_eq!(MAAPrimate::String("".to_string()).as_float(), None);
-        assert_eq!(MAAPrimate::String("".to_string()).as_string(), Some(""));
+        assert_eq!(MAAPrimate::String("".to_string()).as_str(), Some(""));
     }
 }


### PR DESCRIPTION
The return type is `Option<&str>`, so `as_str` is a more appropriate.