### PR TITLE
fix: if start time is later than end, treat it as crossing midnight

### DIFF
--- a/README-EN.md
+++ b/README-EN.md
@@ -212,18 +212,18 @@ facility = ["Trade", "Reception", "Mfg", "Control", "Power", "Office", "Dorm"]
 dorm_trust_enabled = true
 filename = "normal.json" # the filename of custom infrast plan
 
-# use plan 1 before 12:00:00, use plan 2 between 12:00:00 and 18:00:00, use plan 0 after 18:00:00
+# use plan 0 from 18:00:00 to 04:00:00 of next day, use plan 1 before 12:00:00, use plan 2 after 12:00:00
 [[tasks.variants]]
-condition = { type = "Time", end = "12:00:00" } # if start is not defined, it will be 00:00:00
+condition = { type = "Time", start = "18:00:00", end = "04:00:00" } # when end time is less than start time, end time will be treated as time of next day
+params = { plan_index = 0 }
+
+[[tasks.variants]]
+condition = { type = "Time", end = "12:00:00" } # if start time is omitted, this condition will be matched if current time is less than end time
 params = { plan_index = 1 }
 
 [[tasks.variants]]
-condition = { type = "Time", start = "12:00:00", end = "18:00:00" }
+condition = { type = "Time", start = "12:00:00" } # if end time is omitted, this condition will be matched if current time is greater than start time
 params = { plan_index = 2 }
-
-[[tasks.variants]]
-condition = { type = "Time", start = "18:00:00" } # if end is not defined, it will be 23:59:59
-params = { plan_index = 0 }
 ```
 
 The `condition` field is used to determine whether the variant should be used,

--- a/README.md
+++ b/README.md
@@ -227,18 +227,18 @@ facility = ["Trade", "Reception", "Mfg", "Control", "Power", "Office", "Dorm"]
 dorm_trust_enabled = true
 filename = "normal.json" # 自定义的基建计划的文件名应该位于`$MAA_CONFIG_DIR/infrast`
 
-# 在12:00:00之前使用计划1，在12:00:00到18:00:00之间使用计划2，在18:00:00之后使用计划0
+# 在 18:00:00到第二天的 04:00:00 使用计划 0，在 12:00:00 之前使用计划 1，之后使用计划 2
 [[tasks.variants]]
-condition = { type = "Time", end = "12:00:00" } # 如果没有定义start，那么它将会是00:00:00
+condition = { type = "Time", start = "18:00:00", end = "04:00:00" } # 当结束时间小于开始时间时，结束时间被视为第二天的时间
+params = { plan_index = 0 }
+
+[[tasks.variants]]
+condition = { type = "Time", end = "12:00:00" } # 如果开始时间被省略，那么只要当前时间小于结束时间时，这个条件就会被匹配
 params = { plan_index = 1 }
 
 [[tasks.variants]]
-condition = { type = "Time", start = "12:00:00", end = "18:00:00" }
+condition = { type = "Time", start = "12:00:00" } # 如果结束时间被省略，那么只要当前时间大于开始时间时，这个条件就会被匹配
 params = { plan_index = 2 }
-
-[[tasks.variants]]
-condition = { type = "Time", start = "18:00:00" }
-params = { plan_index = 0 }
 ```
 
 这里的 `condition` 字段用于确定哪一个变体应该被使用，而匹配的变体的 `params` 字段将会被合并到任务的参数中。

--- a/maa-cli/Cargo.toml
+++ b/maa-cli/Cargo.toml
@@ -83,7 +83,7 @@ version = "0.10.1"
 default-features = false
 features = ["auto-color"]
 
-# Datatime support
+# Datetime support
 [dependencies.chrono]
 version = "0.4.31"
 default-features = false

--- a/maa-cli/src/config/task/condition.rs
+++ b/maa-cli/src/config/task/condition.rs
@@ -79,16 +79,16 @@ impl Condition {
                 match (start, end) {
                     (Some(s), Some(e)) => time_in_range(&now_time, s, e),
                     (Some(s), None) => now_time >= *s,
-                    (None, Some(e)) => now_time <= *e,
+                    (None, Some(e)) => now_time < *e,
                     (None, None) => true,
                 }
             }
             Condition::DateTime { start, end } => {
                 let now = Local::now().naive_local();
                 match (start, end) {
-                    (Some(s), Some(e)) => now >= *s && now <= *e,
+                    (Some(s), Some(e)) => now >= *s && now < *e,
                     (Some(s), None) => now >= *s,
-                    (None, Some(e)) => now <= *e,
+                    (None, Some(e)) => now < *e,
                     (None, None) => true,
                 }
             }
@@ -116,9 +116,9 @@ impl Condition {
 
 fn time_in_range(time: &NaiveTime, start: &NaiveTime, end: &NaiveTime) -> bool {
     if start <= end {
-        start <= time && time <= end
+        start <= time && time < end
     } else {
-        start <= time || time <= end
+        start <= time || time < end
     }
 }
 
@@ -210,22 +210,19 @@ mod tests {
             let end = time_from_hms(2, 59, 59);
 
             assert!(time_in_range(&time_from_hms(1, 0, 0), &start, &end));
-            assert!(time_in_range(&time_from_hms(2, 59, 59), &start, &end));
             assert!(time_in_range(&time_from_hms(1, 0, 1), &start, &end));
             assert!(time_in_range(&time_from_hms(2, 59, 58), &start, &end));
-
             assert!(!time_in_range(&time_from_hms(0, 59, 59), &start, &end));
-            assert!(!time_in_range(&time_from_hms(3, 0, 0), &start, &end));
+            assert!(!time_in_range(&time_from_hms(2, 59, 59), &start, &end));
 
             let start = time_from_hms(23, 0, 0);
             let end = time_from_hms(1, 59, 59);
 
             assert!(time_in_range(&time_from_hms(23, 0, 0), &start, &end));
-            assert!(time_in_range(&time_from_hms(1, 59, 59), &start, &end));
             assert!(time_in_range(&time_from_hms(23, 0, 1), &start, &end));
             assert!(time_in_range(&time_from_hms(1, 59, 58), &start, &end));
             assert!(!time_in_range(&time_from_hms(22, 59, 59), &start, &end));
-            assert!(!time_in_range(&time_from_hms(2, 0, 0), &start, &end));
+            assert!(!time_in_range(&time_from_hms(1, 59, 59), &start, &end));
         }
 
         #[test]


### PR DESCRIPTION
This will address issues with tests near midnight. However, if the start or end times are omitted, we can't fix it. Therefore, I've also shortened the time range construct in the test to reduce the possibility of test failures. Fix #188 