### PR TITLE
feat: add `preset` field for connection configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ on:
 env:
   RUST_BACKTRACE: full
   CARGO_TERM_COLOR: always
+  MAA_LOG: trace
 
 defaults:
   run:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,6 @@ on:
 env:
   RUST_BACKTRACE: full
   CARGO_TERM_COLOR: always
-  MAA_LOG: trace
 
 defaults:
   run:

--- a/README-EN.md
+++ b/README-EN.md
@@ -463,7 +463,7 @@ The related configurations of `MaaCore` is located in `$MAA_CONFIG_DIR/asst.toml
 
 ```toml
 [connection]
-type = "ADB"
+preset = "MuMuPro"
 adb_path = "adb"
 device = "emulator-5554"
 config = "CompatMac"
@@ -486,33 +486,32 @@ kill_adb_on_exit = false
 
 #### Connection
 
-The `connection` section is used to specify how to connect to the game. Currently, there are two types of connection: `ADB` and `PlayTools`.
-
-If you use `ADB`, you should set `adb_path` and `device` fields:
+The `connection` section is used to specify how to connect to the game:
 
 ```toml
 [connection]
-type = "ADB"
-adb_path = "adb" # the path of adb executable
-device = "emulator-5554" # the serial of your android device
-config = "General" # the config of maa
+adb_path = "adb" # the path of adb executable, default to "adb", which means use adb in PATH
+address = "emulator-5554" # the address of device, such as "emulator-5554" or "127.0.0.1:5555"
+config = "General" # the config of maa, should not be changed most of time
 ```
 
-Note, the `device` field is any valid input of `-s` option of `adb` command, like `emulator-5554` or `127.0.0.1:5555`.
+`adb_path` is the path of `adb` executable, you can set it to the absolute path of `adb` or or leave it empty if it is in PATH.
+You can use `adb` shipped by emulator, like `address` is the address of device used by `adb`, like `emulator-5554` or `127.0.0.1:[port]`.
+`config` used to specify some configurations of host and emulator. It's default value is `CompatMac` on macOS, `CompatPOSIXShell` on Linux and `General` on other platforms. More optional configs can be found in `config.json` in resource directory.
 
-If you use `PlayTools`, you should set `address`
-which is the address of `MaaTools` set in `PlayCover`,
-more details can be found at
-[here](https://maa.plus/docs/en-us/1.4-EMULATOR_SUPPORTS_FOR_MAC.html#✅-playcover-the-software-runs-most-fluently-for-its-nativity-🚀):
+For some common emulators, you can use `preset` to use predefined configurations:
 
 ```toml
 [connection]
-type = "PlayTools"
-address = "localhost:1717" # the address of MaaTools
-config = "CompatMac" # the same as above
+preset = "MuMuPro"
+adb_path = "/path/to/other/adb" # override predefined adb executable path
+address = "127.0.0.1:7777" # override the predefined address
 ```
 
-Both `ADB` and `PlayTools` share the `config` field, which is a parameter of `connect` function of MAA. Its default value is `CompatMac` on macOS, `CompatPOSIXShell` on Linux and `General` on other platforms. More optional configs can be found in `config.json` in resource directory.
+Currently, there is only one preset `MuMuPro` for emulators. Issue and PR are welcome for new preset.
+
+There is a special preset `PlayCover`, used for iOS App running on macOS by PlayCover.
+In this case, `adb_path` is ignored and `address` is used to specify the address of `MaaTools` set in `PlayCover`,
 
 #### Resource
 

--- a/README.md
+++ b/README.md
@@ -465,7 +465,7 @@ description = "medicine to use"
 
 ```toml
 [connection]
-type = "ADB"
+preset = "MuMuPro"
 adb_path = "adb"
 device = "emulator-5554"
 config = "CompatMac"
@@ -488,30 +488,31 @@ kill_adb_on_exit = false
 
 #### 连接配置
 
-`[connection]` 相关字段用于指定 MaaCore 连接游戏的方式和参数。目前可用的连接方式有 `ADB` 和 `PlayTools`。
-
-当你使用 `ADB` 连接时，你需要提供 `adb` 的路径和设备的序列号：
+`[connection]` 相关字段用于指定 MaaCore 连接游戏的参数：
 
 ```toml
 [connection]
-type = "ADB"
-adb_path = "adb" # adb可执行文件的路径
-device = "emulator-5554" # 你的android设备的序列号
-config = "General" # maa connect的配置
+adb_path = "adb" # adb 可执行文件的路径，默认值为 "adb"，这意味着 adb 可执行文件在环境变量 PATH 中
+address = = "emulator-5554" # 连接地址，比如 "emulator-5554" 或者 "127.0.0.1:5555"
+config = "General" # 连接配置，通常不需要修改
 ```
 
-注意，此处的 device 是任何 `adb -s` 可以接受的值，比如 `emulator-5554` 和 `127.0.0.1:5555`。
+`adb_path` 是 `adb` 可执行文件的路径，你可以指定其路径，或者将其添加到环境变量 `PATH` 中，以便 `MaaCore` 可以找到它。大多数模拟器自带 `adb`，你可以直接使用其自带的 `adb`，而不需要额外安装，否则你需要自行安装 `adb`。
+`address` 是 `adb` 的连接地址。对于模拟器，你可以使用 `127.0.0.1:[端口号]`，常用的模拟器端口号参见[常见问题](`https://maa.plus/docs/用户手册/常见问题.html#模拟器调试端口`)。
+`config` 用于指定一些平台和模拟器相关的配置。对于 Linux 他默认为 `CompatPOSIXShell`，对于 macOS 他默认为 `CompatMac`，对于 Windows 他默认为 `General`。更多可选配置可以在资源文件夹中的 `config.json` 文件中找到。
 
-当你使用 `PlayTools` 连接时，你需要提供 `PlayTools` 的地址：
+对于一些常用的模拟器，你可以直接使用 `preset` 来使用预设的配置：
 
 ```toml
 [connection]
-type = "PlayCover"
-address = "localhost:1717" # PlayTools的地址
-config = "CompatMac" # maa connect的配置
+preset = "MuMuPro" # 使用 MuMuPro 预设的连接配置
+adb_path = "/path/to/adb" # 如果你需要的话，你可以覆盖预设的 adb 路径，大多数情况下你不需要这么做
+address = "127.0.0.1:7777" # 如果你需要的话，你可以覆盖预设的地址
 ```
 
-两者都需要提供 `config`，这个值将被传给 MaaCore, 用于指定一些平台和模拟器相关的配置。对于 Linux 他默认为 `CompatPOSIXShell`，对于 macOS 他默认为 `CompatMac`，对于 Windows 他默认为 `General`。更多可选配置可以在资源文件夹中的 `config.json` 文件中找到。
+目前只有 `MuMuPro` 一个模拟器的预设，如果有其他常用模拟器的预设，欢迎提交 issue 或者 PR。
+
+此处有一个特殊的预设 `PlayCover`，其用于在 macOS 上连接直接通过 `PlayCover` 原生运行的游戏客户端。这种情况下不需要指定 `adb_path` 且 `address` 不是 `adb` l连接的地址而是 `PlayTools` 的地址，具体使用参见 [PlayCover 支持文档](https://maa.plus/docs/用户手册/模拟器和设备支持/Mac模拟器.html#✅-playcover-原生运行最流畅-🚀).
 
 #### 资源配置
 

--- a/maa-cli/schemas/asst.schema.json
+++ b/maa-cli/schemas/asst.schema.json
@@ -1,13 +1,24 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://github.com/MaaAssistantArknights/maa-cli/raw/v0.4.0/maa-cli/schemas/asst.schema.json",
+  "$id": "https://github.com/MaaAssistantArknights/maa-cli/raw/v0.4.3/maa-cli/schemas/asst.schema.json",
   "type": "object",
   "properties": {
     "connection": {
-      "oneOf": [
-        { "$ref": "#/definitions/adbConnection" },
-        { "$ref": "#/definitions/playToolsConnection" }
-      ]
+      "type": "object",
+      "properties": {
+        "preset": {
+          "type": "string",
+          "enum": ["ADB", "PlayCover", "MuMuPro"],
+          "default": "ADB"
+        },
+        "adb_path": {
+          "type": "string",
+          "format": "path",
+          "default": "adb"
+        },
+        "address": { "type": "string" },
+        "config": { "type": "string" }
+      }
     },
     "resource": {
       "type": "object",

--- a/maa-cli/src/config/asst.rs
+++ b/maa-cli/src/config/asst.rs
@@ -795,6 +795,30 @@ mod tests {
         }
 
         #[test]
+        fn preset() {
+            assert_eq!(ConnectionConfig::default().preset(), Preset::ADB);
+
+            assert_eq!(
+                ConnectionConfig {
+                    preset: Preset::MuMuPro,
+                    ..Default::default()
+                }
+                .preset(),
+                Preset::MuMuPro
+            );
+        }
+
+        #[test]
+        fn set_address() {
+            let mut config = ConnectionConfig::default();
+            assert_eq!(config.address, None);
+            assert_eq!(
+                config.set_address("127.0.0.1:12345").address,
+                Some("127.0.0.1:12345".to_owned())
+            );
+        }
+
+        #[test]
         fn connect_args() {
             assert_eq!(
                 ConnectionConfig::default().connect_args(),
@@ -814,6 +838,17 @@ mod tests {
                     "127.0.0.1:16384",
                     config_based_on_os(),
                 ),
+            );
+
+            assert_eq!(
+                ConnectionConfig {
+                    preset: Preset::PlayCover,
+                    adb_path: None,
+                    address: None,
+                    config: None,
+                }
+                .connect_args(),
+                ("", "localhost:1717", config_based_on_os()),
             );
 
             assert_eq!(

--- a/maa-cli/src/config/asst.rs
+++ b/maa-cli/src/config/asst.rs
@@ -23,8 +23,7 @@ impl AsstConfig {
         static_options: StaticOptions,
         mut instance_options: InstanceOptions,
     ) -> Self {
-        if matches!(connection.preset, Preset::PlayCover)
-        {
+        if matches!(connection.preset, Preset::PlayCover) {
             info!("Detected connection with PlayTools");
             instance_options.force_playtools();
             resource.use_platform_diff_resource("iOS");
@@ -83,6 +82,7 @@ pub struct ConnectionConfig {
 }
 
 impl ConnectionConfig {
+    #[cfg(target_os = "macos")]
     pub fn preset(&self) -> Preset {
         self.preset
     }
@@ -93,12 +93,25 @@ impl ConnectionConfig {
     }
 
     pub fn connect_args(&self) -> (&str, &str, &str) {
-        let adb_path = self.adb_path.as_deref().unwrap_or_else(|| self.preset.default_adb_path());
-        let address = self.address.as_deref().unwrap_or_else(|| self.preset.default_address());
-        let config = self.config.as_deref().unwrap_or_else(|| self.preset.default_config());
+        let adb_path = self
+            .adb_path
+            .as_deref()
+            .unwrap_or_else(|| self.preset.default_adb_path());
+        let address = self
+            .address
+            .as_deref()
+            .unwrap_or_else(|| self.preset.default_address());
+        let config = self
+            .config
+            .as_deref()
+            .unwrap_or_else(|| self.preset.default_config());
         debug!(
             "Connecting to {address} with config {config} via {}",
-            if matches!(self.preset, Preset::PlayCover) { "PlayTools" } else { adb_path }
+            if matches!(self.preset, Preset::PlayCover) {
+                "PlayTools"
+            } else {
+                adb_path
+            }
         );
 
         (adb_path, address, config)
@@ -144,7 +157,7 @@ impl<'de> Deserialize<'de> for Preset {
                 }
             }
         }
-        
+
         deserializer.deserialize_str(PresetVisitor)
     }
 }
@@ -152,8 +165,7 @@ impl<'de> Deserialize<'de> for Preset {
 impl Preset {
     fn default_adb_path(self) -> &'static str {
         match self {
-            Preset::MuMuPro => 
-                "/Applications/MuMuPlayer.app/Contents/MacOS/MuMuEmulator.app/Contents/MacOS/tools/adb",
+            Preset::MuMuPro => "/Applications/MuMuPlayer.app/Contents/MacOS/MuMuEmulator.app/Contents/MacOS/tools/adb",
             Preset::PlayCover => "",
             Preset::ADB => "adb",
         }
@@ -534,10 +546,7 @@ mod tests {
         fn connection_config() {
             assert_de_tokens(
                 &ConnectionConfig::default(),
-                &[
-                    Token::Map { len: Some(0) },
-                    Token::MapEnd,
-                ],
+                &[Token::Map { len: Some(0) }, Token::MapEnd],
             );
 
             assert_de_tokens(
@@ -602,7 +611,6 @@ mod tests {
                     Token::MapEnd,
                 ],
             );
-
         }
 
         #[test]
@@ -793,7 +801,6 @@ mod tests {
                 ("adb", "emulator-5554", config_based_on_os()),
             );
 
-
             assert_eq!(
                 ConnectionConfig {
                     preset: Preset::MuMuPro,
@@ -809,8 +816,6 @@ mod tests {
                 ),
             );
 
-
-
             assert_eq!(
                 ConnectionConfig {
                     preset: Preset::ADB,
@@ -821,7 +826,6 @@ mod tests {
                 .connect_args(),
                 ("/path/to/adb", "127.0.0.1:11111", "SomeConfig"),
             );
-
         }
     }
 

--- a/maa-cli/src/config/asst.rs
+++ b/maa-cli/src/config/asst.rs
@@ -794,6 +794,7 @@ mod tests {
             );
         }
 
+        #[cfg(target_os = "macos")]
         #[test]
         fn preset() {
             assert_eq!(ConnectionConfig::default().preset(), Preset::ADB);

--- a/maa-cli/src/config/asst.rs
+++ b/maa-cli/src/config/asst.rs
@@ -1,11 +1,8 @@
-use super::FindFileOrDefault;
-
 use crate::dirs::{self, global_path};
 
-use std::{path::PathBuf, sync::Mutex};
+use std::path::PathBuf;
 
 use anyhow::{Context, Result};
-use lazy_static::lazy_static;
 use log::{debug, info, warn};
 use maa_sys::{Assistant, InstanceOptionKey, StaticOptionKey, TouchMode};
 use serde::Deserialize;
@@ -17,6 +14,29 @@ pub struct AsstConfig {
     pub resource: ResourceConfig,
     pub static_options: StaticOptions,
     pub instance_options: InstanceOptions,
+}
+
+impl AsstConfig {
+    pub fn new(
+        connection: ConnectionConfig,
+        mut resource: ResourceConfig,
+        static_options: StaticOptions,
+        mut instance_options: InstanceOptions,
+    ) -> Self {
+        if matches!(connection.preset, Preset::PlayCover)
+        {
+            info!("Detected connection with PlayTools");
+            instance_options.force_playtools();
+            resource.use_platform_diff_resource("iOS");
+        }
+
+        Self {
+            connection,
+            resource,
+            static_options,
+            instance_options,
+        }
+    }
 }
 
 impl<'de> Deserialize<'de> for AsstConfig {
@@ -36,133 +56,130 @@ impl<'de> Deserialize<'de> for AsstConfig {
             instance_options: InstanceOptions,
         }
 
-        let mut config = AsstConfigHelper::deserialize(deserializer)?;
+        let config = AsstConfigHelper::deserialize(deserializer)?;
 
-        if matches!(config.connection, ConnectionConfig::PlayTools { .. }) {
-            info!("Detected connection with PlayTools");
-            config.instance_options.force_playtools();
-            config.resource.use_platform_diff_resource("iOS");
-        }
-
-        Ok(Self {
-            connection: config.connection,
-            resource: config.resource,
-            static_options: config.static_options,
-            instance_options: config.instance_options,
-        })
+        Ok(AsstConfig::new(
+            config.connection,
+            config.resource,
+            config.static_options,
+            config.instance_options,
+        ))
     }
 }
 
 impl super::FromFile for AsstConfig {}
 
-lazy_static! {
-    static ref ASST_CONFIG: Mutex<AsstConfig> = Mutex::new(
-        AsstConfig::find_file_or_default(&dirs::config().join("asst"))
-            .expect("Failed to load asst config")
-    );
-}
-
-pub fn with_asst_config<R>(f: impl FnOnce(&AsstConfig) -> R) -> R {
-    let asst_config = ASST_CONFIG.lock().unwrap();
-    f(&asst_config)
-}
-
-pub fn with_mut_asst_config<R>(f: impl FnOnce(&mut AsstConfig) -> R) -> R {
-    let mut asst_config = ASST_CONFIG.lock().unwrap();
-    f(&mut asst_config)
-}
-
 #[cfg_attr(test, derive(Debug, PartialEq))]
-#[derive(Deserialize, Clone)]
-#[serde(tag = "type")]
-#[serde(deny_unknown_fields)]
-#[allow(clippy::upper_case_acronyms)]
-pub enum ConnectionConfig {
-    ADB {
-        #[serde(default = "default_adb_path")]
-        adb_path: String,
-        #[serde(default = "default_device")]
-        device: String,
-        #[serde(default = "default_config")]
-        config: String,
-    },
-    #[serde(alias = "PlayCover")]
-    PlayTools {
-        #[serde(default = "default_playcover_address")]
-        address: String,
-        #[serde(default = "default_config")]
-        config: String,
-    },
+#[derive(Deserialize, Clone, Default)]
+pub struct ConnectionConfig {
+    #[serde(default, alias = "type")]
+    preset: Preset,
+    #[serde(default)]
+    adb_path: Option<String>,
+    #[serde(default, alias = "device")]
+    address: Option<String>,
+    #[serde(default)]
+    config: Option<String>,
 }
-
-const EMPTY_STR: &str = "";
 
 impl ConnectionConfig {
-    pub fn set_address(&mut self, addr: impl Into<String>) -> &Self {
-        match self {
-            ConnectionConfig::ADB { device, .. } => {
-                *device = addr.into();
-            }
-            ConnectionConfig::PlayTools { address, .. } => {
-                *address = addr.into();
-            }
-        }
+    pub fn preset(&self) -> Preset {
+        self.preset
+    }
+
+    pub fn set_address(&mut self, address: impl Into<String>) -> &mut Self {
+        self.address = Some(address.into());
         self
     }
 
     pub fn connect_args(&self) -> (&str, &str, &str) {
+        let adb_path = self.adb_path.as_deref().unwrap_or_else(|| self.preset.default_adb_path());
+        let address = self.address.as_deref().unwrap_or_else(|| self.preset.default_address());
+        let config = self.config.as_deref().unwrap_or_else(|| self.preset.default_config());
+        debug!(
+            "Connecting to {address} with config {config} via {}",
+            if matches!(self.preset, Preset::PlayCover) { "PlayTools" } else { adb_path }
+        );
+
+        (adb_path, address, config)
+    }
+}
+
+#[cfg_attr(test, derive(Debug, PartialEq))]
+#[derive(Default, Clone, Copy)]
+#[allow(clippy::upper_case_acronyms)]
+pub enum Preset {
+    MuMuPro,
+    PlayCover,
+    #[default]
+    ADB,
+}
+
+impl<'de> Deserialize<'de> for Preset {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct PresetVisitor;
+
+        impl<'de> serde::de::Visitor<'de> for PresetVisitor {
+            type Value = Preset;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+                formatter.write_str("a connection preset name")
+            }
+
+            fn visit_str<E>(self, value: &str) -> std::result::Result<Preset, E>
+            where
+                E: serde::de::Error,
+            {
+                match value {
+                    "MuMuPro" => Ok(Preset::MuMuPro),
+                    "PlayCover" | "PlayTools" => Ok(Preset::PlayCover),
+                    "ADB" => Ok(Preset::ADB),
+                    _ => {
+                        warn!("Unknown connection preset: {}, ignoring", value);
+                        Ok(Preset::ADB)
+                    }
+                }
+            }
+        }
+        
+        deserializer.deserialize_str(PresetVisitor)
+    }
+}
+
+impl Preset {
+    fn default_adb_path(self) -> &'static str {
         match self {
-            ConnectionConfig::ADB {
-                adb_path,
-                device,
-                config,
-            } => {
-                debug!(
-                    "Connecting to {} with config {} via {}",
-                    device, config, adb_path
-                );
-                (adb_path, device, config)
-            }
-            ConnectionConfig::PlayTools { address, config } => {
-                debug!(
-                    "Connecting to {} with config {} via PlayTools",
-                    address, config
-                );
-                (EMPTY_STR, address, config)
-            }
+            Preset::MuMuPro => 
+                "/Applications/MuMuPlayer.app/Contents/MacOS/MuMuEmulator.app/Contents/MacOS/tools/adb",
+            Preset::PlayCover => "",
+            Preset::ADB => "adb",
         }
+    }
+
+    fn default_address(self) -> &'static str {
+        match self {
+            Preset::MuMuPro => "127.0.0.1:16384",
+            Preset::PlayCover => "localhost:1717",
+            Preset::ADB => "emulator-5554",
+        }
+    }
+
+    fn default_config(self) -> &'static str {
+        // May be preset specific in the future
+        config_based_on_os()
     }
 }
 
-impl Default for ConnectionConfig {
-    fn default() -> Self {
-        ConnectionConfig::ADB {
-            adb_path: default_adb_path(),
-            device: default_device(),
-            config: default_config(),
-        }
-    }
-}
-
-fn default_adb_path() -> String {
-    String::from("adb")
-}
-
-fn default_device() -> String {
-    String::from("emulator-5554")
-}
-
-fn default_playcover_address() -> String {
-    String::from("localhost:1717")
-}
-
-fn default_config() -> String {
+fn config_based_on_os() -> &'static str {
     if cfg!(target_os = "macos") {
-        String::from("CompatMac")
+        "CompatMac"
     } else if cfg!(target_os = "linux") {
-        String::from("CompatPOSIXShell")
+        "CompatLinux"
     } else {
-        String::from("General")
+        "General"
     }
 }
 
@@ -454,6 +471,8 @@ mod tests {
 
     use crate::assert_matches;
 
+    use lazy_static::lazy_static;
+
     lazy_static! {
         static ref USER_RESOURCE_DIR: PathBuf = {
             let user_resource_dir = dirs::config().join("resource");
@@ -481,10 +500,11 @@ mod tests {
             assert_eq!(
                 config,
                 AsstConfig {
-                    connection: ConnectionConfig::ADB {
-                        adb_path: String::from("adb"),
-                        device: String::from("emulator-5554"),
-                        config: String::from("CompatMac"),
+                    connection: ConnectionConfig {
+                        preset: Preset::ADB,
+                        adb_path: Some(String::from("adb")),
+                        address: Some(String::from("emulator-5554")),
+                        config: Some(String::from("CompatMac")),
                     },
                     resource: ResourceConfig {
                         resource_base_dirs: {
@@ -513,10 +533,17 @@ mod tests {
         #[test]
         fn connection_config() {
             assert_de_tokens(
-                &ConnectionConfig::ADB {
-                    adb_path: default_adb_path(),
-                    device: default_device(),
-                    config: default_config(),
+                &ConnectionConfig::default(),
+                &[
+                    Token::Map { len: Some(0) },
+                    Token::MapEnd,
+                ],
+            );
+
+            assert_de_tokens(
+                &ConnectionConfig {
+                    preset: Preset::ADB,
+                    ..Default::default()
                 },
                 &[
                     Token::Map { len: Some(1) },
@@ -527,54 +554,55 @@ mod tests {
             );
 
             assert_de_tokens(
-                &ConnectionConfig::ADB {
-                    adb_path: String::from("/path/to/adb"),
-                    device: String::from("127.0.0.1:5555"),
-                    config: String::from("SomeConfig"),
+                &ConnectionConfig {
+                    preset: Preset::ADB,
+                    ..Default::default()
+                },
+                &[
+                    Token::Map { len: Some(1) },
+                    Token::Str("preset"),
+                    Token::Str("ADB"),
+                    Token::MapEnd,
+                ],
+            );
+
+            assert_de_tokens(
+                &ConnectionConfig {
+                    preset: Preset::MuMuPro,
+                    ..Default::default()
+                },
+                &[
+                    Token::Map { len: Some(4) },
+                    Token::Str("preset"),
+                    Token::Str("MuMuPro"),
+                    Token::MapEnd,
+                ],
+            );
+
+            assert_de_tokens(
+                &ConnectionConfig {
+                    preset: Preset::ADB,
+                    adb_path: Some(String::from("/path/to/adb")),
+                    address: Some(String::from("127.0.0.1:5555")),
+                    config: Some(String::from("SomeConfig")),
                 },
                 &[
                     Token::Map { len: Some(4) },
                     Token::Str("type"),
                     Token::Str("ADB"),
                     Token::Str("adb_path"),
+                    Token::Some,
                     Token::Str("/path/to/adb"),
                     Token::Str("device"),
+                    Token::Some,
                     Token::Str("127.0.0.1:5555"),
                     Token::Str("config"),
+                    Token::Some,
                     Token::Str("SomeConfig"),
                     Token::MapEnd,
                 ],
             );
 
-            assert_de_tokens(
-                &ConnectionConfig::PlayTools {
-                    address: default_playcover_address(),
-                    config: default_config(),
-                },
-                &[
-                    Token::Map { len: Some(1) },
-                    Token::Str("type"),
-                    Token::Str("PlayTools"),
-                    Token::MapEnd,
-                ],
-            );
-
-            assert_de_tokens(
-                &ConnectionConfig::PlayTools {
-                    address: String::from("localhost:7777"),
-                    config: String::from("SomeConfig"),
-                },
-                &[
-                    Token::Map { len: Some(3) },
-                    Token::Str("type"),
-                    Token::Str("PlayTools"),
-                    Token::Str("address"),
-                    Token::Str("localhost:7777"),
-                    Token::Str("config"),
-                    Token::Str("SomeConfig"),
-                    Token::MapEnd,
-                ],
-            )
         }
 
         #[test]
@@ -691,11 +719,7 @@ mod tests {
         fn asst_config() {
             assert_de_tokens(
                 &AsstConfig {
-                    connection: ConnectionConfig::ADB {
-                        adb_path: default_adb_path(),
-                        device: default_device(),
-                        config: default_config(),
-                    },
+                    connection: ConnectionConfig::default(),
                     resource: ResourceConfig {
                         resource_base_dirs: default_resource_base_dirs(),
                         global_resource: None,
@@ -719,9 +743,9 @@ mod tests {
             // Auto load iOS resource and set touch mode to MacPlayTools
             assert_de_tokens(
                 &AsstConfig {
-                    connection: ConnectionConfig::PlayTools {
-                        address: default_playcover_address(),
-                        config: default_config(),
+                    connection: ConnectionConfig {
+                        preset: Preset::PlayCover,
+                        ..Default::default()
                     },
                     resource: ResourceConfig {
                         platform_diff_resource: Some(PathBuf::from("iOS")),
@@ -753,58 +777,51 @@ mod tests {
         fn default() {
             assert_matches!(
                 ConnectionConfig::default(),
-                ConnectionConfig::ADB {
-                    adb_path,
-                    device,
-                    config,
-                } if adb_path == default_adb_path()
-                    && device == default_device()
-                    && config == default_config()
+                ConnectionConfig {
+                    preset: Preset::ADB,
+                    adb_path: None,
+                    address: None,
+                    config: None,
+                }
             );
-        }
-
-        #[test]
-        fn set_address() {
-            assert_matches!(
-                ConnectionConfig::default().set_address("127.0.0.1:5555"),
-                ConnectionConfig::ADB {
-                    device,
-                    ..
-                } if device == "127.0.0.1:5555"
-            );
-
-            assert_matches!(
-                ConnectionConfig::PlayTools {
-                    address: default_playcover_address(),
-                    config: default_config(),
-                }.set_address("localhost:7777"),
-                ConnectionConfig::PlayTools {
-                    address,
-                    ..
-                } if address == "localhost:7777"
-            )
         }
 
         #[test]
         fn connect_args() {
             assert_eq!(
-                ConnectionConfig::ADB {
-                    adb_path: "adb".to_owned(),
-                    device: "emulator-5554".to_owned(),
-                    config: "General".to_owned(),
-                }
-                .connect_args(),
-                ("adb", "emulator-5554", "General")
+                ConnectionConfig::default().connect_args(),
+                ("adb", "emulator-5554", config_based_on_os()),
             );
 
+
             assert_eq!(
-                ConnectionConfig::PlayTools {
-                    address: "localhost:7777".to_owned(),
-                    config: "SomeConfig".to_owned(),
+                ConnectionConfig {
+                    preset: Preset::MuMuPro,
+                    adb_path: None,
+                    address: None,
+                    config: None,
                 }
                 .connect_args(),
-                (EMPTY_STR, "localhost:7777", "SomeConfig")
+                (
+                    "/Applications/MuMuPlayer.app/Contents/MacOS/MuMuEmulator.app/Contents/MacOS/tools/adb",
+                    "127.0.0.1:16384",
+                    config_based_on_os(),
+                ),
             );
+
+
+
+            assert_eq!(
+                ConnectionConfig {
+                    preset: Preset::ADB,
+                    adb_path: Some("/path/to/adb".to_owned()),
+                    address: Some("127.0.0.1:11111".to_owned()),
+                    config: Some("SomeConfig".to_owned()),
+                }
+                .connect_args(),
+                ("/path/to/adb", "127.0.0.1:11111", "SomeConfig"),
+            );
+
         }
     }
 

--- a/maa-cli/src/main.rs
+++ b/maa-cli/src/main.rs
@@ -442,7 +442,12 @@ mod test {
 
         #[test]
         fn global_options() {
-            env::remove_var("MAA_LOG");
+            let old = if let Some(val) = env::var_os("MAA_LOG") {
+                env::remove_var("MAA_LOG");
+                Some(val)
+            } else {
+                None
+            };
 
             assert_eq!(
                 CLI::parse_from(["maa", "list"]).verbose.log_level_filter(),
@@ -486,7 +491,11 @@ mod test {
                 CLI::parse_from(["maa", "list"]).verbose.log_level_filter(),
                 log::LevelFilter::Info
             );
-            env::remove_var("MAA_LOG");
+
+            // Restore the environment variable
+            if let Some(old) = old {
+                env::set_var("MAA_LOG", old);
+            }
 
             assert!(!CLI::parse_from(["maa", "list"]).batch);
             assert!(CLI::parse_from(["maa", "list", "--batch"]).batch);

--- a/maa-cli/src/run/mod.rs
+++ b/maa-cli/src/run/mod.rs
@@ -10,11 +10,7 @@ mod playcover;
 pub mod preset;
 
 use crate::{
-    config::{
-        asst::{AsstConfig, Preset},
-        task::TaskConfig,
-        FindFileOrDefault,
-    },
+    config::{asst::AsstConfig, task::TaskConfig, FindFileOrDefault},
     consts::MAA_CORE_LIB,
     dirs::{self, Ensure},
     installer::resource,
@@ -158,7 +154,7 @@ where
     // Only support PlayCover on macOS now, may support more in the future
     #[cfg(target_os = "macos")]
     let app = match asst_config.connection.preset() {
-        Preset::PlayCover => playcover::PlayCoverApp::new(
+        crate::config::asst::Preset::PlayCover => playcover::PlayCoverApp::new(
             task_config.start_app,
             task_config.close_app,
             task_config.client_type.unwrap_or_default(),

--- a/maa-cli/src/run/mod.rs
+++ b/maa-cli/src/run/mod.rs
@@ -11,8 +11,9 @@ pub mod preset;
 
 use crate::{
     config::{
-        asst::{with_asst_config, with_mut_asst_config, AsstConfig},
+        asst::{AsstConfig, Preset},
         task::TaskConfig,
+        FindFileOrDefault,
     },
     consts::MAA_CORE_LIB,
     dirs::{self, Ensure},
@@ -94,24 +95,29 @@ fn run_core<F>(f: F, args: CommonArgs) -> Result<()>
 where
     F: FnOnce(&AsstConfig) -> Result<TaskConfig>,
 {
+    // Auto update hot update resource
     resource::update(true)?;
 
-    // Prepare config
-    with_mut_asst_config(|config| args.apply_to(config));
-    let task = with_asst_config(f)?;
+    // Load asst config
+    let mut asst_config = AsstConfig::find_file_or_default(&dirs::config().join("asst"))
+        .context("Failed to find asst config file!")?;
+
+    args.apply_to(&mut asst_config);
+
+    let task = f(&asst_config)?;
     let task_config = task.init()?;
     if let Some(client_type) = task_config.client_type {
         debug!("Detected client type: {}", client_type);
         if let Some(resource) = client_type.resource() {
-            with_mut_asst_config(|config| {
-                config.resource.use_global_resource(resource);
-            });
+            asst_config.resource.use_global_resource(resource);
         }
     }
 
+    // Load and setup MaaCore
     load_core().context("Failed to load MaaCore!")?;
-    with_asst_config(setup_core)?;
+    setup_core(&asst_config)?;
 
+    // Register signal handlers
     let stop_bool = Arc::new(std::sync::atomic::AtomicBool::new(false));
     for sig in TERM_SIGNALS {
         signal_hook::flag::register_conditional_default(*sig, Arc::clone(&stop_bool))
@@ -120,10 +126,11 @@ where
             .context("Failed to register signal handler!")?;
     }
 
+    // Create and setup Assistant
     let asst = Assistant::new(Some(callback::default_callback), None);
+    asst_config.instance_options.apply_to(&asst)?;
 
-    with_asst_config(|config| config.instance_options.apply_to(&asst))?;
-
+    // Register tasks
     let mut summarys = (!args.no_summary).then(summary::Summary::new);
     for task in task_config.tasks.iter() {
         let name = task.name();
@@ -144,34 +151,33 @@ where
         summary::init(s);
     }
 
+    // Prepare connection
+    let (adb, addr, config) = asst_config.connection.connect_args();
+
+    // Launch external app like PlayCover or Emulator
+    // Only support PlayCover on macOS now, may support more in the future
     #[cfg(target_os = "macos")]
-    let app = with_asst_config(|config| {
-        use crate::config::asst::ConnectionConfig::PlayTools;
-        if let PlayTools { ref address, .. } = config.connection {
-            playcover::PlayCoverApp::new(
-                task_config.start_app,
-                task_config.close_app,
-                task_config.client_type.unwrap_or_default(),
-                address.to_owned(),
-            )
-        } else {
-            None
-        }
-    });
+    let app = match asst_config.connection.preset() {
+        Preset::PlayCover => playcover::PlayCoverApp::new(
+            task_config.start_app,
+            task_config.close_app,
+            task_config.client_type.unwrap_or_default(),
+            addr,
+        ),
+        _ => None,
+    };
 
     if !args.dry_run {
+        // Startup external app
         #[cfg(target_os = "macos")]
         let rt = Runtime::new().context("Failed to create tokio runtime")?;
-
         #[cfg(target_os = "macos")]
         if let Some(app) = app.as_ref() {
             rt.block_on(app.open())?;
         }
 
-        with_asst_config(|config| {
-            let (adb, addr, config) = config.connection.connect_args();
-            asst.async_connect(adb, addr, config, true)
-        })?;
+        // Connect to game or emulator
+        asst.async_connect(adb, addr, config, true)?;
 
         asst.start()?;
 
@@ -184,6 +190,7 @@ where
 
         asst.stop()?;
 
+        // Close external app
         #[cfg(target_os = "macos")]
         if let Some(app) = app.as_ref() {
             rt.block_on(app.close())?;

--- a/maa-cli/src/run/playcover.rs
+++ b/maa-cli/src/run/playcover.rs
@@ -8,15 +8,15 @@ use tokio::{io::AsyncWriteExt, net::TcpStream};
 const TERMINATE: &[u8] = &[0x4d, 0x41, 0x41, 0x00, 0x00, 0x04, 0x54, 0x45, 0x52, 0x4d];
 
 #[cfg_attr(test, derive(PartialEq, Debug))]
-pub struct PlayCoverApp {
+pub struct PlayCoverApp<'a> {
     client: ClientType,
-    address: String,
+    address: &'a str,
     start: bool,
     close: bool,
 }
 
-impl PlayCoverApp {
-    pub fn new(start: bool, close: bool, client: ClientType, address: String) -> Option<Self> {
+impl<'a> PlayCoverApp<'a> {
+    pub fn new(start: bool, close: bool, client: ClientType, address: &'a str) -> Option<Self> {
         if start || close {
             Some(Self {
                 client,
@@ -30,7 +30,7 @@ impl PlayCoverApp {
     }
 
     async fn connect(&self) -> Result<TcpStream> {
-        let stream = TcpStream::connect(&self.address)
+        let stream = TcpStream::connect(self.address)
             .await
             .context("Failed to connect to game!")?;
 
@@ -89,27 +89,27 @@ mod tests {
     fn from() {
         use crate::config::task::ClientType::*;
         assert_eq!(
-            PlayCoverApp::new(true, true, Official, "localhost:1717".to_string(),),
+            PlayCoverApp::new(true, true, Official, "localhost:1717"),
             Some(PlayCoverApp {
                 start: true,
                 close: true,
                 client: Official,
-                address: "localhost:1717".to_string(),
+                address: "localhost:1717",
             })
         );
 
         assert_eq!(
-            PlayCoverApp::new(false, true, Official, "localhost:1717".to_string(),),
+            PlayCoverApp::new(false, true, Official, "localhost:1717"),
             Some(PlayCoverApp {
                 start: false,
                 close: true,
                 client: Official,
-                address: "localhost:1717".to_string(),
+                address: "localhost:1717",
             })
         );
 
         assert_eq!(
-            PlayCoverApp::new(false, false, Official, "localhost:1717".to_string(),),
+            PlayCoverApp::new(false, false, Official, "localhost:1717"),
             None
         );
     }


### PR DESCRIPTION
The preset define some default value of connection configuration, only support `MuMuPro` and `PlayCover` now.

The old `type` have become alias `preset` for compatibility.