### PR TITLE
ci: split coverage and test, install core with prebuilt maa

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -101,7 +101,7 @@ runs:
         package_name=$(basename "$(ls "$(./maa dir cache)")")
         echo "Downloaded MaaCore package: $package_name"
         core_version=${package_name#MAA-v}
-        core_version=${version%%-*}
+        core_version=${core_version%%-*}
         if [[ $core_version =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
           echo "Downloaded MaaCore version: $core_version"
           echo "MAA_CORE_VERSION=v$core_version" >> "$GITHUB_ENV"

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -63,10 +63,28 @@ runs:
         tool: cargo-tarpaulin
     - name: Install Prebuilt CLI
       if: fromJson(inputs.core)
-      uses: jaxxstorm/action-install-gh-release@v1
-      with:
-        repo: MaaAssistantArknights/maa-cli
-        tag: v0.4.3
+      shell: bash
+      run: |
+        cli_version=v0.4.3
+        url="https://github.com/MaaAssistantArknights/maa-cli/releases/download/$cli_version"
+
+        case "$CARGO_BUILD_TARGET" in
+          *-unknown-linux-gnu)
+            aria2c "$url/maa_cli-$cli_version-$CARGO_BUILD_TARGET.tar.gz"
+            tar -xzvf maa_cli-$cli_version-$CARGO_BUILD_TARGET.tar.gz
+            cp -v maa_cli-$cli_version-$CARGO_BUILD_TARGET/maa .
+          ;;
+          *-apple-darwin)
+            aria2c "$url/maa_cli-$cli_version-$CARGO_BUILD_TARGET.zip"
+            unzip -v maa_cli-$cli_version-$CARGO_BUILD_TARGET.zip
+            cp -v maa_cli-$cli_version-$CARGO_BUILD_TARGET/maa .
+          ;;
+          *-pc-windows-msvc)
+            aria2c "$url/maa_cli-$cli_version-$CARGO_BUILD_TARGET.zip"
+            unzip -v maa_cli-$cli_version-$CARGO_BUILD_TARGET.zip
+            cp -v maa_cli-$cli_version-$CARGO_BUILD_TARGET/maa.exe .
+          ;;
+        esac
     - name: Install MaaCore and resource
       if: fromJson(inputs.core)
       shell: bash
@@ -74,15 +92,15 @@ runs:
         export MAA_CONFIG_DIR="$GITHUB_WORKSPACE/maa-cli/config_examples"
         export MAA_LOG="debug"
 
-        maa install stable
-        MAA_CORE_DIR="$(maa dir lib)"
-        MAA_RESOURCE_DIR="$(maa dir resource)"
+        ./maa install stable
+        MAA_CORE_DIR="$(./maa dir lib)"
+        MAA_RESOURCE_DIR="$(./maa dir resource)"
         ls -l "$MAA_CORE_DIR"
         ls -l "$MAA_RESOURCE_DIR"
         echo "MAA_CORE_DIR=$MAA_CORE_DIR" >> $GITHUB_ENV
         echo "MAA_RESOURCE_DIR=$MAA_RESOURCE_DIR" >> $GITHUB_ENV
 
-        package_name=$(basename "$(ls "$(maa dir cache)")")
+        package_name=$(basename "$(ls "$(./maa dir cache)")")
         echo "Downloaded MaaCore package: $package_name"
         version=${package_name#MAA-v}
         version=${version%%-*}

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -72,17 +72,17 @@ runs:
           *-unknown-linux-gnu)
             aria2c "$url/maa_cli-$cli_version-$CARGO_BUILD_TARGET.tar.gz"
             tar -xzvf maa_cli-$cli_version-$CARGO_BUILD_TARGET.tar.gz
-            cp -v maa_cli-$cli_version-$CARGO_BUILD_TARGET/maa .
+            cp -v maa_cli-$CARGO_BUILD_TARGET/maa .
           ;;
           *-apple-darwin)
             aria2c "$url/maa_cli-$cli_version-$CARGO_BUILD_TARGET.zip"
             unzip -v maa_cli-$cli_version-$CARGO_BUILD_TARGET.zip
-            cp -v maa_cli-$cli_version-$CARGO_BUILD_TARGET/maa .
+            cp -v maa_cli-$CARGO_BUILD_TARGET/maa .
           ;;
           *-pc-windows-msvc)
             aria2c "$url/maa_cli-$cli_version-$CARGO_BUILD_TARGET.zip"
             unzip -v maa_cli-$cli_version-$CARGO_BUILD_TARGET.zip
-            cp -v maa_cli-$cli_version-$CARGO_BUILD_TARGET/maa.exe .
+            cp -v maa_cli-$CARGO_BUILD_TARGET/maa.exe .
           ;;
         esac
     - name: Install MaaCore and resource

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -89,7 +89,6 @@ runs:
       shell: bash
       run: |
         export MAA_CONFIG_DIR="$GITHUB_WORKSPACE/maa-cli/config_examples"
-        export MAA_LOG="debug"
 
         ./maa install stable
         MAA_CORE_DIR="$(./maa dir lib)"

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,19 +1,23 @@
 name: Setup Rust
-description: 'Setup Rust for cross-compilation'
+description: Setup Rust for cross-compilation
 inputs:
   os:
-    description: 'Host and target OS'
+    description: Host and target OS
     required: true
   arch:
-    description: 'Target architecture'
+    description: Target architecture
     required: true
   coverage:
-    description: 'Whether to install cargo-tarpaulin'
+    description: Whether to install cargo-tarpaulin
     required: false
-    default: 'false'
+    default: "false"
+  core:
+    description: Whether to install MaaCore and resource
+    required: false
+    default: "false"
 
 runs:
-  using: 'composite'
+  using: composite
   steps:
     - name: Compute Target Triple
       shell: bash
@@ -57,3 +61,43 @@ runs:
       uses: taiki-e/install-action@v2
       with:
         tool: cargo-tarpaulin
+    - name: Install MaaCore and resource
+      if: fromJson(inputs.core)
+      shell: bash
+      run: |
+        version=0.4.2
+        url="https://github.com/MaaAssistantArknights/maa-cli/releases/download/$version/"
+        case "$CARGO_BUILD_TARGET" in
+          *-unknown-linux-gnu)
+            curl -sL $url/maa_cli-$version-$CARGO_BUILD_TARGET.tar.gz | tar xz
+            export PATH="maa_cli-$version-$CARGO_BUILD_TARGET:$PATH"
+            ;;
+          *-apple-darwin)
+            curl -sL $url/maa_cli-$version-$CARGO_BUILD_TARGET.zip | unzip -q -
+            export PATH="maa_cli-$version-$CARGO_BUILD_TARGET:$PATH"
+            ;;
+          *-pc-windows-msvc)
+            curl -sL $url/maa_cli-$version-$CARGO_BUILD_TARGET.zip | unzip -q -
+            export PATH="maa_cli-$version-$CARGO_BUILD_TARGET:$PATH"
+            ;;
+        esac
+
+        export MAA_CONFIG_DIR="$GITHUB_WORKSPACE/maa-cli/config_examples"
+        export MAA_LOG="debug"
+
+        maa install stable
+        MAA_CORE_DIR="$(maa dir lib)"
+        MAA_RESOURCE_DIR="$(maa dir resource)"
+        ls -l "$MAA_CORE_DIR"
+        ls -l "$MAA_RESOURCE_DIR"
+        echo "MAA_CORE_DIR=$MAA_CORE_DIR" >> $GITHUB_ENV
+        echo "MAA_RESOURCE_DIR=$MAA_RESOURCE_DIR" >> $GITHUB_ENV
+
+        package_name=$(basename "$(ls "$(maa dir cache)")")
+        echo "Downloaded MaaCore package: $package_name"
+        version=${package_name#MAA-v}
+        version=${version%%-*}
+        if [[ $version =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+          echo "Downloaded MaaCore version: $version"
+          echo "MAA_CORE_VERSION=v$version" >> "$GITHUB_ENV"
+        fi

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -61,27 +61,16 @@ runs:
       uses: taiki-e/install-action@v2
       with:
         tool: cargo-tarpaulin
+    - name: Install Prebuilt CLI
+      if: fromJson(inputs.core)
+      uses: jaxxstorm/action-install-gh-release@v1
+      with:
+        repo: MaaAssistantArknights/maa-cli
+        tag: v0.4.3
     - name: Install MaaCore and resource
       if: fromJson(inputs.core)
       shell: bash
       run: |
-        version=0.4.2
-        url="https://github.com/MaaAssistantArknights/maa-cli/releases/download/$version/"
-        case "$CARGO_BUILD_TARGET" in
-          *-unknown-linux-gnu)
-            curl -sL $url/maa_cli-$version-$CARGO_BUILD_TARGET.tar.gz | tar xz
-            export PATH="maa_cli-$version-$CARGO_BUILD_TARGET:$PATH"
-            ;;
-          *-apple-darwin)
-            curl -sL $url/maa_cli-$version-$CARGO_BUILD_TARGET.zip | unzip -q -
-            export PATH="maa_cli-$version-$CARGO_BUILD_TARGET:$PATH"
-            ;;
-          *-pc-windows-msvc)
-            curl -sL $url/maa_cli-$version-$CARGO_BUILD_TARGET.zip | unzip -q -
-            export PATH="maa_cli-$version-$CARGO_BUILD_TARGET:$PATH"
-            ;;
-        esac
-
         export MAA_CONFIG_DIR="$GITHUB_WORKSPACE/maa-cli/config_examples"
         export MAA_LOG="debug"
 

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -67,7 +67,6 @@ runs:
       run: |
         cli_version=v0.4.3
         url="https://github.com/MaaAssistantArknights/maa-cli/releases/download/$cli_version"
-
         case "$CARGO_BUILD_TARGET" in
           *-unknown-linux-gnu)
             aria2c "$url/maa_cli-$cli_version-$CARGO_BUILD_TARGET.tar.gz"
@@ -76,12 +75,12 @@ runs:
           ;;
           *-apple-darwin)
             aria2c "$url/maa_cli-$cli_version-$CARGO_BUILD_TARGET.zip"
-            unzip -v maa_cli-$cli_version-$CARGO_BUILD_TARGET.zip
+            unzip maa_cli-$cli_version-$CARGO_BUILD_TARGET.zip
             cp -v maa_cli-$CARGO_BUILD_TARGET/maa .
           ;;
           *-pc-windows-msvc)
             aria2c "$url/maa_cli-$cli_version-$CARGO_BUILD_TARGET.zip"
-            unzip -v maa_cli-$cli_version-$CARGO_BUILD_TARGET.zip
+            unzip maa_cli-$cli_version-$CARGO_BUILD_TARGET.zip
             cp -v maa_cli-$CARGO_BUILD_TARGET/maa.exe .
           ;;
         esac
@@ -102,9 +101,10 @@ runs:
 
         package_name=$(basename "$(ls "$(./maa dir cache)")")
         echo "Downloaded MaaCore package: $package_name"
-        version=${package_name#MAA-v}
-        version=${version%%-*}
-        if [[ $version =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-          echo "Downloaded MaaCore version: $version"
-          echo "MAA_CORE_VERSION=v$version" >> "$GITHUB_ENV"
+        core_version=${package_name#MAA-v}
+        core_version=${version%%-*}
+        if [[ $core_version =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+          echo "Downloaded MaaCore version: $core_version"
+          echo "MAA_CORE_VERSION=v$core_version" >> "$GITHUB_ENV"
         fi
+        echo "MAA_CORE_INSTALLED=true" >> "$GITHUB_ENV"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,23 +102,6 @@ jobs:
           core: true
       - name: Setup Cache
         uses: Swatinem/rust-cache@v2
-      - name: Install MaaCore
-        env:
-          MAA_CONFIG_DIR: ${{ github.workspace }}/maa-cli/config_examples
-        run: |
-          cargo run -- install stable
-          ls -l "$(cargo run -- dir library)"
-          ls -l "$(cargo run -- dir resource)"
-          ls -l "$(cargo run -- dir cache)"
-          package_name=$(basename "$(ls "$(cargo run -- dir cache)")")
-          echo "Downloaded MaaCore package: $package_name"
-          version=${package_name#MAA-v}
-          version=${version%%-*}
-          if [[ $version =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "Downloaded MaaCore version: $version"
-            echo "MAA_CORE_VERSION=v$version" >> "$GITHUB_ENV"
-          fi
-          echo "MAA_CORE_INSTALLED=true" >> "$GITHUB_ENV"
       - name: Coverage
         run: |
           cargo tarpaulin --out xml --all --timeout 120 \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,8 +149,6 @@ jobs:
           os: ${{ matrix.os }}
           arch: x86_64
           core: true
-      - name: Setup Cache
-        uses: Swatinem/rust-cache@v2
       - name: Build
         run: cargo build --package maa-sys --locked
       - name: Lint (clippy)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,6 @@ jobs:
         with:
           os: ${{ matrix.os }}
           arch: x86_64
-          coverage: true
       - name: Setup Cache
         uses: Swatinem/rust-cache@v2
       - name: Build (maa-cli)
@@ -84,6 +83,49 @@ jobs:
           cargo tarpaulin --packages maa-cli --timeout 120 --out xml \
             ${{ github.run_attempt == 1 && '--skip-clean' || '' }} \
             -- --include-ignored
+      - name: Upload to codecov.io
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: true
+
+  coverage:
+    name: Coverage
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Rust
+        uses: ./.github/actions/setup
+        with:
+          os: ubuntu-latest
+          arch: x86_64
+          coverage: true
+          core: true
+      - name: Setup Cache
+        uses: Swatinem/rust-cache@v2
+      - name: Install MaaCore
+        env:
+          MAA_CONFIG_DIR: ${{ github.workspace }}/maa-cli/config_examples
+        run: |
+          cargo run -- install stable
+          ls -l "$(cargo run -- dir library)"
+          ls -l "$(cargo run -- dir resource)"
+          ls -l "$(cargo run -- dir cache)"
+          package_name=$(basename "$(ls "$(cargo run -- dir cache)")")
+          echo "Downloaded MaaCore package: $package_name"
+          version=${package_name#MAA-v}
+          version=${version%%-*}
+          if [[ $version =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Downloaded MaaCore version: $version"
+            echo "MAA_CORE_VERSION=v$version" >> "$GITHUB_ENV"
+          fi
+          echo "MAA_CORE_INSTALLED=true" >> "$GITHUB_ENV"
+      - name: Coverage
+        run: |
+          cargo tarpaulin --out xml --all --timeout 120 \
+            ${{ github.run_attempt == 1 && '--skip-clean' || '' }}
       - name: Upload to codecov.io
         uses: codecov/codecov-action@v4
         with:
@@ -160,19 +202,9 @@ jobs:
           os: ${{ matrix.os }}
           arch: x86_64
           coverage: true
+          core: true
       - name: Setup Cache
         uses: Swatinem/rust-cache@v2
-      - name: Install MaaCore
-        env:
-          MAA_CONFIG_DIR: ${{ github.workspace }}/maa-cli/config_examples
-        run: |
-          cargo run -- install stable -t0
-          MAA_CORE_DIR="$(cargo run -- dir lib)"
-          MAA_RESOURCE_DIR="$(cargo run -- dir resource)"
-          ls -l "$MAA_CORE_DIR"
-          ls -l "$MAA_RESOURCE_DIR"
-          echo "MAA_CORE_DIR=$MAA_CORE_DIR" >> $GITHUB_ENV
-          echo "MAA_RESOURCE_DIR=$MAA_RESOURCE_DIR" >> $GITHUB_ENV
       - name: Build
         run: cargo build --package maa-sys --locked
       - name: Lint (clippy)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,7 +131,7 @@ jobs:
           cargo test -- --include-ignored
 
   build-sys:
-    name: Build and test (maa-sys, static)
+    name: Build and Test (maa-sys, static)
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,28 +78,25 @@ jobs:
       - name: Test
         run: |
           cargo test -- --include-ignored
-      - name: Coverage
-        run: |
-          cargo tarpaulin --packages maa-cli --timeout 120 --out xml \
-            ${{ github.run_attempt == 1 && '--skip-clean' || '' }} \
-            -- --include-ignored
-      - name: Upload to codecov.io
-        uses: codecov/codecov-action@v4
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          fail_ci_if_error: true
 
   coverage:
     name: Coverage
-    runs-on: ubuntu-latest
     needs: build
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+          - windows-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Setup Rust
         uses: ./.github/actions/setup
         with:
-          os: ubuntu-latest
+          os: ${{ matrix.os }}
           arch: x86_64
           coverage: true
           core: true
@@ -201,8 +198,8 @@ jobs:
         with:
           os: ${{ matrix.os }}
           arch: x86_64
-          coverage: true
-          core: true
+          coverage: ${{ !startsWith(matrix.os , 'windows') }}
+          core: ${{ !startsWith(matrix.os , 'windows') }}
       - name: Setup Cache
         uses: Swatinem/rust-cache@v2
       - name: Build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,7 +182,7 @@ jobs:
           os: ${{ matrix.os }}
           arch: x86_64
           coverage: ${{ !startsWith(matrix.os , 'windows') }}
-          core: ${{ !startsWith(matrix.os , 'windows') }}
+          core: true
       - name: Setup Cache
         uses: Swatinem/rust-cache@v2
       - name: Build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,8 +187,9 @@ jobs:
         uses: Swatinem/rust-cache@v2
       - name: Coverage
         run: |
-          cargo tarpaulin --out xml --all --timeout 120 \
-            ${{ github.run_attempt == 1 && '--skip-clean' || '' }}
+          cargo tarpaulin --out xml --workspace --timeout 120 \
+            ${{ github.run_attempt == 1 && '--skip-clean' || '' }} \
+            -- --include-ignored
       - name: Upload to codecov.io
         uses: codecov/codecov-action@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,39 +79,6 @@ jobs:
         run: |
           cargo test -- --include-ignored
 
-  coverage:
-    name: Coverage
-    needs: build
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os:
-          - ubuntu-latest
-          - macos-latest
-          - windows-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Setup Rust
-        uses: ./.github/actions/setup
-        with:
-          os: ${{ matrix.os }}
-          arch: x86_64
-          coverage: true
-          core: true
-      - name: Setup Cache
-        uses: Swatinem/rust-cache@v2
-      - name: Coverage
-        run: |
-          cargo tarpaulin --out xml --all --timeout 120 \
-            ${{ github.run_attempt == 1 && '--skip-clean' || '' }}
-      - name: Upload to codecov.io
-        uses: codecov/codecov-action@v4
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          fail_ci_if_error: true
-
   build-aarch64:
     name: Build (aarch64)
     runs-on: ${{ matrix.os }}
@@ -181,7 +148,6 @@ jobs:
         with:
           os: ${{ matrix.os }}
           arch: x86_64
-          coverage: ${{ !startsWith(matrix.os , 'windows') }}
           core: true
       - name: Setup Cache
         uses: Swatinem/rust-cache@v2
@@ -197,13 +163,35 @@ jobs:
         # https://stackoverflow.com/questions/63394094/rust-linker-seeks-a-lib-rather-than-a-dll
         if: ${{ !startsWith(matrix.os, 'windows') }}
         run: cargo test --package maa-sys
+
+  coverage:
+    name: Coverage
+    needs: [build, build-sys]
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+          - windows-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Rust
+        uses: ./.github/actions/setup
+        with:
+          os: ${{ matrix.os }}
+          arch: x86_64
+          coverage: true
+          core: true
+      - name: Setup Cache
+        uses: Swatinem/rust-cache@v2
       - name: Coverage
-        if: ${{ !startsWith(matrix.os, 'windows') }}
         run: |
-          cargo tarpaulin --packages maa-sys --timeout 120 --out xml \
+          cargo tarpaulin --out xml --all --timeout 120 \
             ${{ github.run_attempt == 1 && '--skip-clean' || '' }}
       - name: Upload to codecov.io
-        if: ${{ !startsWith(matrix.os, 'windows') }}
         uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
I have no idea but it seems that cache for coverage break the cache for build.