### PR TITLE
feat: add env `MAA_LOG_PREFIX` to control prefix in log

### DIFF
--- a/README-EN.md
+++ b/README-EN.md
@@ -6,6 +6,8 @@
 ![Beta Release](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fgithub.com%2FMaaAssistantArknights%2Fmaa-cli%2Fraw%2Fversion%2Fbeta.json&query=%24.version&prefix=v&label=beta)
 ![platform](https://img.shields.io/badge/platform-Windows%20%7C%20Linux%20%7C%20macOS-blueviolet)
 
+<!-- markdownlint-disable MD013 MD033 -->
+
 A simple CLI for [MAA](https://github.com/MaaAssistantArknights/MaaAssistantArknights) by Rust.
 
 ## Feature
@@ -133,6 +135,17 @@ You can run a custom task by `maa run <task>`. Here `<task>` is the name of a ta
 #### Task Summary
 
 `maa-cli` will print a summary of each task to stdout when finished. The summary can be disabled by `--no-summary` option.
+
+#### Logging
+
+There are 5 levels of logging: `Trace`, `Debug`, `Info`, `Warn`, `Error`, which determine the verbosity of logging.
+You can set the log level by environment variable `MAA_LOG`, such as `MAA_LOG=debug`.
+You can also increase and decrease the log level by `-v` and `-q` option.
+If no log level is set, the default log level is `Warn`, which means only `Warn` and `Error` logs will be printed.
+
+By default, `maa-cli` will print logs to stderr. You can redirect logs to a file by `--log-file` option, the default log path is `$(maa dir log)/YYYY/MM/DD/HH:MM:SS.log` where `$(maa dir log)` is the log directory. You can also specify the log path by `--log-file=<path>`.
+
+When log print to file, there will be a prefix with timestamp and log level, whereas log print to stderr, there will be no prefix. You can change this behavior by `MAA_LOG_PREFIX` environment variable. Set it to `Always` to always print prefix, set it to `Never` to never print prefix, set it to `Auto` (default) to print prefix only when log to file.
 
 ### Install and update
 
@@ -282,7 +295,7 @@ condition = {
         # The offset is equal to num_days_since_ce % divisor
         # The num_days_since_ce is the number of days since the Common Era, 0001-01-01 is the first day
         # The offset of current day can be got by `maa remainder <divisor>`
-        # for 2024-01-27, num_days_since_ce is 738,912, 
+        # for 2024-01-27, num_days_since_ce is 738,912,
         # the offset of 2024-01-27 is 738,912 % 2 = 0
         # so this condition will be matched on 2024-01-27
         { type = "DayMod", divisor = 2, remainder = 0 },

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 [English](./README-EN.md)
 
 <!-- LTeX: language=zh-CN -->
+<!-- markdownlint-disable MD013 MD033 -->
 
 一个使用 Rust 编写的简单 [MAA](https://github.com/MaaAssistantArknights/MaaAssistantArknights) 命令行工具。
 
@@ -147,9 +148,11 @@ OpenSSL 库是 `git2` 在所有平台和 `reqwest` 在 Linux 上的依赖。如�
 
 #### 日志输出
 
-`maa-cli` 默认会向 stderr 输出日志。日志输出级别从低到高分别为 `Error`，`Warn`，`Info`，`Debug` 和 `Trace`。默认的日志输出级别为 `Warn`。日志级别可以通过 `MAA_LOG` 环境变量来设置，例如 `MAA_LOG=debug`。你也可以通过 `-v` 或者 `-q` 来增加或者减少日志输出级别。
+日志输出级别从低到高分别为 `Error`，`Warn`，`Info`，`Debug` 和 `Trace`。默认的日志输出级别为 `Warn`。日志级别可以通过 `MAA_LOG` 环境变量来设置，例如 `MAA_LOG=debug`。你也可以通过 `-v` 或者 `-q` 来增加或者减少日志输出级别。
 
-`--log-file` 选项可以将日志输出到文件中，日志保存在 `$(maa dir log)/YYYY/MM/DD/HH:MM:SS.log` 中，其中 `$(maa dir log)` 是日志目录，你可以通过 `maa dir log` 获取。你也可以通过 `--log-file=path/to/log` 来指定日志文件的路径。
+`maa-cli` 默认会向 stderr 输出日志。`--log-file` 选项可以将日志输出到文件中，日志保存在 `$(maa dir log)/YYYY/MM/DD/HH:MM:SS.log` 中，其中 `$(maa dir log)` 是日志目录，你可以通过 `maa dir log` 获取。你也可以通过 `--log-file=path/to/log` 来指定日志文件的路径。
+
+默认情况下，向 stderr 输出的日志不会包含时间戳和日志级别，但是向文件输出的日志会包含时间戳和日志级别的前缀。你可以通过环境变量 `MAA_LOG_PREFIX` 来改变这个行为。设置为 `Always` 时，总是会包含前缀，而设置为 `Never` 时即使是写入日志文件时也不会包含前缀。
 
 ### 安装和更新
 

--- a/maa-cli/src/main.rs
+++ b/maa-cli/src/main.rs
@@ -16,7 +16,7 @@ use crate::installer::maa_cli;
 #[cfg(feature = "core_installer")]
 use crate::installer::maa_core;
 
-use std::path::PathBuf;
+use std::{io::Write, path::PathBuf};
 
 use anyhow::{Context, Result};
 use clap::{CommandFactory, Parser, Subcommand, ValueEnum};
@@ -285,22 +285,78 @@ pub enum Dir {
     Log,
 }
 
+/// Whether or not to print log prefix [YYYY-MM-DD HH:MM:SS LEVEL]
+#[cfg_attr(test, derive(Debug, PartialEq))]
+#[derive(Clone, Copy, Default)]
+enum LogPrefix {
+    /// Print log prefix if log to file, not print log prefix if log to stderr
+    #[default]
+    Auto,
+    /// Always print log prefix
+    Always,
+    /// Never print log prefix
+    Never,
+}
+
+impl LogPrefix {
+    fn from_str(s: &str) -> Option<Self> {
+        match s {
+            "ALWAYS" | "Always" | "always" => Some(LogPrefix::Always),
+            "NEVER" | "Never" | "never" => Some(LogPrefix::Never),
+            "AUTO" | "Auto" | "auto" => Some(LogPrefix::Auto),
+            _ => None,
+        }
+    }
+
+    fn from_env() -> Self {
+        std::env::var_os("MAA_LOG_PREFIX")
+            .and_then(|s| s.to_str().and_then(LogPrefix::from_str))
+            .unwrap_or_default()
+    }
+
+    fn format(
+        &self,
+        log_file: bool,
+    ) -> fn(&mut env_logger::fmt::Formatter, &log::Record) -> std::io::Result<()> {
+        match self {
+            LogPrefix::Always => prefixed_format,
+            LogPrefix::Never => plain_format,
+            LogPrefix::Auto => {
+                if log_file {
+                    prefixed_format
+                } else {
+                    plain_format
+                }
+            }
+        }
+    }
+}
+
+fn prefixed_format(
+    buf: &mut env_logger::fmt::Formatter,
+    record: &log::Record,
+) -> std::io::Result<()> {
+    writeln!(
+        buf,
+        "[{} {:<5}] {}",
+        chrono::Local::now().format("%Y-%m-%d %H:%M:%S"),
+        buf.default_styled_level(record.level()),
+        record.args()
+    )
+}
+
+fn plain_format(buf: &mut env_logger::fmt::Formatter, record: &log::Record) -> std::io::Result<()> {
+    writeln!(buf, "{}", record.args())
+}
+
 fn main() -> Result<()> {
     let cli = CLI::parse();
 
     let mut builder = env_logger::Builder::new();
 
     builder.filter_level(cli.verbose.log_level_filter());
-    builder.format(|buf, record| {
-        use std::io::Write;
-        writeln!(
-            buf,
-            "[{} {:<5}] {}",
-            chrono::Local::now().format("%Y-%m-%d %H:%M:%S"),
-            buf.default_styled_level(record.level()),
-            record.args()
-        )
-    });
+
+    builder.format(LogPrefix::from_env().format(cli.log_file.is_some()));
 
     if let Some(opt) = cli.log_file {
         let now = chrono::Local::now();
@@ -327,9 +383,7 @@ fn main() -> Result<()> {
         enable_batch_mode()
     }
 
-    let subcommand = cli.command;
-
-    match subcommand {
+    match cli.command {
         #[cfg(feature = "core_installer")]
         SubCommand::Install { force, common } => {
             maa_core::install(force, &common)?;
@@ -442,6 +496,53 @@ mod test {
         ($value:expr, $pattern:pat $(if $guard:expr)? $(,)?) => {
             assert!(matches!($value, $pattern $(if $guard)?))
         };
+    }
+
+    mod log_prefix {
+        use super::*;
+
+        #[test]
+        fn from_str() {
+            assert_eq!(LogPrefix::from_str("Always"), Some(LogPrefix::Always));
+            assert_eq!(LogPrefix::from_str("always"), Some(LogPrefix::Always));
+            assert_eq!(LogPrefix::from_str("NEVER"), Some(LogPrefix::Never));
+            assert_eq!(LogPrefix::from_str("never"), Some(LogPrefix::Never));
+            assert_eq!(LogPrefix::from_str("AUTO"), Some(LogPrefix::Auto));
+            assert_eq!(LogPrefix::from_str("auto"), Some(LogPrefix::Auto));
+            assert_eq!(LogPrefix::from_str("unknown"), None);
+        }
+
+        #[test]
+        fn from_env() {
+            std::env::remove_var("MAA_LOG_PREFIX");
+            assert_eq!(LogPrefix::from_env(), LogPrefix::Auto);
+
+            std::env::set_var("MAA_LOG_PREFIX", "Always");
+            assert_eq!(LogPrefix::from_env(), LogPrefix::Always);
+
+            std::env::set_var("MAA_LOG_PREFIX", "Never");
+            assert_eq!(LogPrefix::from_env(), LogPrefix::Never);
+
+            std::env::set_var("MAA_LOG_PREFIX", "Auto");
+            assert_eq!(LogPrefix::from_env(), LogPrefix::Auto);
+        }
+
+        #[test]
+        fn format() {
+            let pff = prefixed_format
+                as fn(&mut env_logger::fmt::Formatter, &log::Record) -> std::io::Result<()>;
+            let plf = plain_format
+                as fn(&mut env_logger::fmt::Formatter, &log::Record) -> std::io::Result<()>;
+
+            assert_eq!(LogPrefix::Always.format(true), pff);
+            assert_eq!(LogPrefix::Always.format(false), pff);
+
+            assert_eq!(LogPrefix::Never.format(true), plf);
+            assert_eq!(LogPrefix::Never.format(false), plf);
+
+            assert_eq!(LogPrefix::Auto.format(true), pff);
+            assert_eq!(LogPrefix::Auto.format(false), plf);
+        }
     }
 
     mod parser {


### PR DESCRIPTION
There are three log prefix mod:

- Auto (default): print prefix when log to file, not otherwise;
- Always: always print prefix;
- Never: never print prefix.