### PR TITLE
ci: match beta tag when release a non-stable release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,7 +86,11 @@ jobs:
           # If the release is triggered by a tag, process commits starting
           # from the latest tag, otherwise tag will be create later, so use
           # unreleased commits
-          args: -vv ${{ github.event_name == 'push' && '-l' || '-u' }}
+          args: >
+            -v
+            ${{ github.event_name == 'push' && '-l' || '-u' }}
+            ${{ needs.meta.outputs.channel != 'stable' && '--tag-pattern="^v"' || '' }}
+
       - name: Preview Release Notes
         if: ${{ !fromJson(needs.meta.outputs.publish) }}
         run: |

--- a/cliff.toml
+++ b/cliff.toml
@@ -132,7 +132,7 @@ protect_breaking_commits = false
 # filter out the commits that are not matched by commit parsers
 filter_commits = false
 # glob pattern for matching git tags
-tag_pattern = "^v[0-9]+.[0-9]+.[0-9]+$"
+tag_pattern = "^v[0-9]+\\.[0-9]+\\.[0-9]+$"
 # regex for skipping tags
 # skip_tags = "v0.1.0-beta.1"
 # regex for ignoring tags


### PR DESCRIPTION
Currently, the generated release notes include all changes starting from the latest stable tag. However, in this PR, non-stable releases (beta and nightly) will only include changes starting from the latest beta tag, making it easier to compare two beta releases.