### PR TITLE
ci: replace macOS 12 with macOS 14 in some CI jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,7 +108,7 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-          - macos-12
+          - macos-14
           - windows-latest
         feature:
           - core_installer # disabled cli_installer and git2, used by package manager
@@ -162,7 +162,6 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-          - macos-12 # x86_64 runner
           - macos-14 # aarch64 runner
           - windows-latest
     env:


### PR DESCRIPTION
The macOS 12 runner is much slower than the macOS 14 runner, so we remove the macOS 12 runner from coverage jobs, and replace it with the macOS 14 runner in the build-feature jobs.