### PR TITLE
test: compare `BTreeSet` instead of `Vec` in cleanup

### DIFF
--- a/maa-cli/src/cleanup.rs
+++ b/maa-cli/src/cleanup.rs
@@ -206,7 +206,7 @@ mod tests {
 
     use crate::dirs::Ensure;
 
-    use std::env::temp_dir;
+    use std::{collections::BTreeSet, env::temp_dir};
 
     mod cleanup_target {
         use super::*;
@@ -378,8 +378,11 @@ mod tests {
                 .read_dir()
                 .unwrap()
                 .map(|x| x.unwrap().file_name().to_str().unwrap().to_string())
-                .collect::<Vec<_>>(),
-            vec!["test1", "test2"]
+                .collect::<BTreeSet<_>>(),
+            ["test1", "test2"]
+                .iter()
+                .map(|x| x.to_string())
+                .collect::<BTreeSet<_>>()
         );
         cleanup(&[All]).unwrap();
 


### PR DESCRIPTION
The order of the files in the directory is not guaranteed, and it may change between runs. Thus, we should compare the `BTreeSet` instead of the `Vec`.