### PR TITLE
feat: detect device address by `adb devices`

### DIFF
--- a/maa-cli/docs/en-US/config.md
+++ b/maa-cli/docs/en-US/config.md
@@ -325,7 +325,7 @@ address = "emulator-5554" # the address of device, such as "emulator-5554" or "1
 config = "General" # the config of maa, should not be changed most of time
 ```
 
-`adb_path` is the path of `adb` executable, you can set it to the absolute path of `adb` or or leave it empty if it is in PATH. The `address` is the address of the device used by `adb`, like `emulator-5554` or `127.0.0.1:[port]`, the port of some common emulators can be found in the [MAA FAQ][emulator-ports]. The `config` is used to specify some configurations of the host and emulator, whose default value is `CompatMac` on macOS, `CompatPOSIXShell` on Linux and `General` on other platforms. More optional configs can be found in `config.json` in the resource directory.
+`adb_path` is the path of `adb` executable, you can set it to the absolute path of `adb` or or leave it empty if it is in PATH. The `address` is the address of the device used by `adb`, like `emulator-5554` or `127.0.0.1:[port]`, the port of some common emulators can be found in the [MAA FAQ][emulator-ports]. If the `address` is absent, the cli will try to find the device automatically by `adb devices`, if there are multiple online devices, the first one will be used. If cli can not find any device, it will try to use the default address `emulator-5554`. The `config` is used to specify some configurations of the host and emulator, whose default value is `CompatMac` on macOS, `CompatPOSIXShell` on Linux and `General` on other platforms. More optional configs can be found in `config.json` in the resource directory.
 
 For some common emulators, you can use `preset` to use predefined configurations:
 

--- a/maa-cli/docs/zh-CN/config.md
+++ b/maa-cli/docs/zh-CN/config.md
@@ -312,7 +312,7 @@ address = = "emulator-5554" # 连接地址，比如 "emulator-5554" 或者 "127.
 config = "General" # 连接配置，通常不需要修改
 ```
 
-`adb_path` 是 `adb` 可执行文件的路径，你可以指定其路径，或者将其添加到环境变量 `PATH` 中，以便 MaaCore 可以找到它。大多数模拟器自带 `adb`，你可以直接使用其自带的 `adb`，而不需要额外安装，否则你需要自行安装 `adb`。`address` 是 `adb` 的连接地址。对于模拟器，你可以使用 `127.0.0.1:[端口号]`，常用的模拟器端口号参见[常见问题][emulator-ports]。`config` 用于指定一些平台和模拟器相关的配置。对于 Linux 他默认为 `CompatPOSIXShell`，对于 macOS 他默认为 `CompatMac`，对于 Windows 他默认为 `General`。更多可选配置可以在资源文件夹中的 `config.json` 文件中找到。
+`adb_path` 是 `adb` 可执行文件的路径，你可以指定其路径，或者将其添加到环境变量 `PATH` 中，以便 MaaCore 可以找到它。大多数模拟器自带 `adb`，你可以直接使用其自带的 `adb`，而不需要额外安装，否则你需要自行安装 `adb`。`address` 是 `adb` 的连接地址。对于模拟器，你可以使用 `127.0.0.1:[端口号]`，常用的模拟器端口号参见[常见问题][emulator-ports]。如果你没有指定 `address`，那么会尝试通过 `adb devices` 来获取连接的设备，如果有多个设备连接，那么将会使用第一个设备，如果没有找到任何设备，那么将会尝试连接到 `emulator-5554`。`config` 用于指定一些平台和模拟器相关的配置。对于 Linux 他默认为 `CompatPOSIXShell`，对于 macOS 他默认为 `CompatMac`，对于 Windows 他默认为 `General`。更多可选配置可以在资源文件夹中的 `config.json` 文件中找到。
 
 对于一些常用的模拟器，你可以直接使用 `preset` 来使用预设的配置：
 

--- a/maa-cli/src/run/mod.rs
+++ b/maa-cli/src/run/mod.rs
@@ -185,7 +185,7 @@ where
             task_config.start_app,
             task_config.close_app,
             task_config.client_type.unwrap_or_default(),
-            addr,
+            addr.as_ref(),
         ),
         _ => None,
     };
@@ -200,7 +200,7 @@ where
         }
 
         // Connect to game or emulator
-        asst.async_connect(adb, addr, config, true)?;
+        asst.async_connect(adb, addr.as_ref(), config, true)?;
 
         asst.start()?;
 


### PR DESCRIPTION
If the `address` is absent, the cli will try to find the device automatically by `adb devices`, if there are multiple online devices, the first one will be used. If cli can not find any device, it will try to use the default address `emulator-5554`. 