### PR TITLE
feat: improve optional value

### DIFF
--- a/maa-cli/docs/en-US/config.md
+++ b/maa-cli/docs/en-US/config.md
@@ -272,10 +272,14 @@ params = { stage = "CE-6" }
 [tasks.variants.params.stage]
 default = "1-7" # default value of stage, optional (if not given, user can input empty value to re-prompt)
 description = "a stage to fight" # description of the input, optional
+
+# query the medicine to use only when stage is 1-7
 [tasks.variants.params.medicine]
-# dependency of parameters, the key is the name of parameter, the value is the expected value of dependency parameter
-# when set, the parameter will be required to input only if all dependency parameters are satisfied
-deps = { stage = "1-7" }
+# a parameter can be optional with `optional` field
+# if the condition is not matched, the parameter will be ignored
+# the `condition` field can be used to specify the condition of the parameter
+# where the condition can be a table, whose keys are name of other parameters and values are the expected value
+conditions = { stage = "1-7" }
 default = 1000
 description = "medicine to use"
 ```

--- a/maa-cli/docs/zh-CN/config.md
+++ b/maa-cli/docs/zh-CN/config.md
@@ -259,10 +259,13 @@ params = { stage = "CE-6" }
 [tasks.variants.params.stage]
 default = "1-7" # 默认的关卡，可选（如果没有默认值，输入空值将会重新提示输入）
 description = "a stage to fight" # 描述，可选
+
+# 当输入的关卡是 1-7 时，需要输入使用理智药的数量
 [tasks.variants.params.medicine]
-# 依赖的参数，键为参数名，值为依赖的参数的预期值
-# 当设置时，只有所有的依赖参数都满足预期值时，这个参数才会被要求输入
-deps = { stage = "1-7" }
+# 参数可以设置为条件参数，这样只有满足条件时才需要输入
+# conditions 字段是一个表，其中键是同一层级下其他参数名，值是期望的值
+# 这里的条件是 stage 是 1-7， 如果存在多个条件，那么所有条件都必须满足
+conditions = { stage = "1-7" }
 default = 1000
 description = "medicine to use"
 ```

--- a/maa-cli/src/config/task/mod.rs
+++ b/maa-cli/src/config/task/mod.rs
@@ -519,18 +519,19 @@ mod tests {
             }
 
             fn example_task_config() -> TaskConfig {
-                use crate::value::Map;
                 use ClientType::*;
-                use MAAValue::OptionalInput;
 
                 let mut task_list = TaskConfig::new();
 
                 task_list.push(Task::new_with_default(
                     StartUp,
                     object!(
-                        "client_type" => OptionalInput {
-                            deps: Map::from([("start_game_enabled".to_string(), true.into())]),
-                            input: SelectD::<String>::new(
+                        "start_game_enabled" => BoolInput::new(
+                            Some(true),
+                            Some("start the game"),
+                        ),
+                        "client_type" if "start_game_enabled" == true =>
+                            SelectD::<String>::new(
                                 vec![
                                     Official.as_ref(),
                                     YoStarEN.as_ref(),
@@ -539,12 +540,7 @@ mod tests {
                                 None,
                                 Some("a client type"),
                                 false
-                            ).unwrap().into(),
-                        },
-                        "start_game_enabled" => BoolInput::new(
-                            Some(true),
-                            Some("start the game"),
-                        ),
+                            ).unwrap(),
                     ),
                 ));
 

--- a/maa-cli/src/run/preset/copilot.rs
+++ b/maa-cli/src/run/preset/copilot.rs
@@ -2,10 +2,7 @@ use crate::{
     config::task::{Task, TaskConfig},
     dirs::{self, Ensure},
     object,
-    value::{
-        userinput::{BoolInput, Input},
-        MAAValue,
-    },
+    value::userinput::{BoolInput, Input},
 };
 
 use std::{

--- a/maa-cli/src/run/preset/roguelike.rs
+++ b/maa-cli/src/run/preset/roguelike.rs
@@ -1,10 +1,7 @@
 use crate::{
     config::task::{Task, TaskConfig},
     object,
-    value::{
-        userinput::{BoolInput, Input, SelectD, ValueWithDesc},
-        MAAValue, Map,
-    },
+    value::userinput::{BoolInput, Input, SelectD, ValueWithDesc},
 };
 
 use anyhow::Result;
@@ -42,7 +39,6 @@ impl ValueEnum for Theme {
 pub fn roguelike(theme: Theme) -> Result<TaskConfig> {
     let mut task_config = TaskConfig::new();
 
-    use MAAValue::OptionalInput;
     let params = object!(
         "theme" => theme.to_str(),
         "mode" => SelectD::<i32>::new([
@@ -53,14 +49,10 @@ pub fn roguelike(theme: Theme) -> Result<TaskConfig> {
         ], Some(1), Some("Roguelike mode"), false).unwrap(),
         "start_count" => Input::<i32>::new(Some(999), Some("number of times to start a new run")),
         "investment_disabled" => BoolInput::new(Some(false), Some("disable investment")),
-        "investments_count" => OptionalInput {
-            deps: Map::from([("investment_disabled".to_string(), false.into())]),
-            input: Input::<i32>::new(Some(999), Some("number of times to invest")).into(),
-        },
-        "stop_when_investment_full" => OptionalInput {
-            deps: Map::from([("investment_disabled".to_string(), false.into())]),
-            input: BoolInput::new(Some(false), Some("stop when investment is full")).into(),
-        },
+        "investments_count" if "investment_disabled" == false =>
+            Input::<i32>::new(Some(999), Some("number of times to invest")),
+        "stop_when_investment_full" if "investment_disabled" == false =>
+            BoolInput::new(Some(false), Some("stop when investment is full")),
         "squad" => Input::<String>::new(None, Some("squad name")),
         "roles" => Input::<String>::new(None, Some("roles")),
         "core_char" => SelectD::<String>::new(
@@ -70,14 +62,10 @@ pub fn roguelike(theme: Theme) -> Result<TaskConfig> {
             true,
         ).unwrap(),
         "use_support" => BoolInput::new(Some(false), Some("use support operator")),
-        "use_nonfriend_support" => OptionalInput {
-            deps: Map::from([("use_support".to_string(), true.into())]),
-            input: BoolInput::new(Some(false), Some("use non-friend support operator")).into(),
-        },
-        "refresh_trader_with_dice" => OptionalInput {
-            deps: Map::from([("theme".to_string(), "Mizuki".into())]),
-            input: BoolInput::new(Some(false), Some("refresh trader with dice")).into(),
-        },
+        "use_nonfriend_support" if "use_support" == true =>
+            BoolInput::new(Some(false), Some("use non-friend support operator")),
+        "refresh_trader_with_dice" if "theme" == "Mizuki" =>
+            BoolInput::new(Some(false), Some("refresh trader with dice")),
     );
 
     task_config.push(Task::new_with_default(Roguelike, params));
@@ -88,6 +76,8 @@ pub fn roguelike(theme: Theme) -> Result<TaskConfig> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    use crate::value::MAAValue;
 
     #[test]
     fn theme_to_str() {


### PR DESCRIPTION
- Rename `OptionalInput` to `Optional`;
- Rename `deps` to `conditions` in `Optional`;
- Rename `input` to `value` in `Optional` and can be any boxed `MAAValue`;
- Fix initialize order of values in an object:
  The current sort implementation is incorrect. The `sort_by` function is only suitable for sorting elements with a total order, whereas the dependencies exhibit a partial order. In the current implementation, we define a total order that combines dependencies and key names, which is not transitive, even in the absence of circular dependencies. For instance, if A depends on B, B depends on C, and C depends on D, then it should be A < B < C < D. However, C and A are both `Optional` and do not directly depend on each other. Consequently, they will be compared by their keys, and the order may be C > A, which contradicts the dependencies. We should not use keys to compare elements, but rather the dependencies. Although the dependencies are a partial order, we can sort them using a topological sort (depth-first search).
- Improve the macro `object!` that can be used to create optional.