### PR TITLE
refactor(sys): parse and convert of `TouchMode` and `TaskType`

### DIFF
--- a/maa-sys/Cargo.toml
+++ b/maa-sys/Cargo.toml
@@ -13,7 +13,7 @@ runtime = ["libloading"]
 
 [dependencies]
 libloading = { version = "0.8", optional = true }
-serde = { version = "1", optional = true, features = ["derive"] }
+serde = { version = "1", optional = true }
 
 [dev-dependencies]
 serde_test = "1"

--- a/maa-sys/src/asst_type.rs
+++ b/maa-sys/src/asst_type.rs
@@ -74,8 +74,9 @@ pub enum TouchMode {
 }
 
 impl TouchMode {
-    const COUNT: usize = 4;
-    const VARIANTS: [TouchMode; Self::COUNT] = {
+    pub const COUNT: usize = 4;
+
+    pub const VARIANTS: [TouchMode; Self::COUNT] = {
         let mut i = 0;
         let mut variants = [TouchMode::ADB; Self::COUNT];
         while i < Self::COUNT {
@@ -95,7 +96,7 @@ impl TouchMode {
         }
     }
 
-    const NAMES: [&'static str; Self::COUNT] = {
+    pub const NAMES: [&'static str; Self::COUNT] = {
         let mut i = 0;
         let mut names = [""; Self::COUNT];
         while i < Self::COUNT {

--- a/maa-sys/src/asst_type.rs
+++ b/maa-sys/src/asst_type.rs
@@ -144,7 +144,7 @@ impl std::error::Error for UnknownTouchModeError {}
 impl std::str::FromStr for TouchMode {
     type Err = UnknownTouchModeError;
 
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
         Self::from_str_opt(s).ok_or_else(|| UnknownTouchModeError(s.to_owned()))
     }
 }

--- a/maa-sys/src/asst_type.rs
+++ b/maa-sys/src/asst_type.rs
@@ -79,7 +79,7 @@ impl TouchMode {
         let mut i = 0;
         let mut variants = [TouchMode::ADB; Self::COUNT];
         while i < Self::COUNT {
-            variants[i] = unsafe { std::mem::transmute(i as u8) };
+            variants[i] = unsafe { std::mem::transmute::<u8, Self>(i as u8) };
             i += 1;
         }
         variants

--- a/maa-sys/src/error.rs
+++ b/maa-sys/src/error.rs
@@ -49,4 +49,4 @@ impl Error {
 }
 
 /// Similar to `anyhow::Result<T>` but the default error type is [`Error`].
-pub type Result<T> = std::result::Result<T, Error>;
+pub type Result<T, E = Error> = std::result::Result<T, E>;

--- a/maa-sys/src/error.rs
+++ b/maa-sys/src/error.rs
@@ -49,4 +49,4 @@ impl Error {
 }
 
 /// Similar to `anyhow::Result<T>` but the default error type is [`Error`].
-pub type Result<T, E = Error> = std::result::Result<T, E>;
+pub type Result<T> = std::result::Result<T, Error>;

--- a/maa-sys/src/task_type.rs
+++ b/maa-sys/src/task_type.rs
@@ -27,7 +27,7 @@ impl TaskType {
         let mut i = 0;
         let mut variants = [Self::StartUp; Self::COUNT];
         while i < Self::COUNT {
-            variants[i] = unsafe { std::mem::transmute(i as u8) };
+            variants[i] = unsafe { std::mem::transmute::<u8, Self>(i as u8) };
             i += 1;
         }
         variants
@@ -120,7 +120,7 @@ impl<'de> serde::Deserialize<'de> for TaskType {
                 E: serde::de::Error,
             {
                 TaskType::from_str_opt(value)
-                    .ok_or_else(|| E::unknown_variant(&value, &TaskType::NAMES))
+                    .ok_or_else(|| E::unknown_variant(value, &TaskType::NAMES))
             }
         }
 

--- a/maa-sys/src/task_type.rs
+++ b/maa-sys/src/task_type.rs
@@ -175,10 +175,6 @@ mod tests {
             "Unknown".parse::<TaskType>(),
             Err(UnknownTaskType("Unknown".to_owned()))
         );
-    }
-
-    #[test]
-    fn unknown_task_type_error() {
         assert_eq!(
             UnknownTaskType("Unknown".to_owned()).to_string(),
             "unknown task type `Unknown`, expected one of `StartUp`, `CloseDown`, `Fight`, \

--- a/maa-sys/src/task_type.rs
+++ b/maa-sys/src/task_type.rs
@@ -21,9 +21,9 @@ pub enum TaskType {
 }
 
 impl TaskType {
-    const COUNT: usize = 16;
+    pub const COUNT: usize = 16;
 
-    const VARIANTS: [Self; Self::COUNT] = {
+    pub const VARIANTS: [Self; Self::COUNT] = {
         let mut i = 0;
         let mut variants = [Self::StartUp; Self::COUNT];
         while i < Self::COUNT {
@@ -54,7 +54,7 @@ impl TaskType {
         }
     }
 
-    const NAMES: [&'static str; Self::COUNT] = {
+    pub const NAMES: [&'static str; Self::COUNT] = {
         let mut i = 0;
         let mut names = [""; Self::COUNT];
         while i < Self::COUNT {


### PR DESCRIPTION
- Implement parse for `TouchMode`;
- Implement `const fn to_str` for `TouchMode` and `TaskType`;
- `AsRef<str>` for them is deprecated and will be removed at next minor version;
- Implement `COUNT`, `NAMES`, `VARIANCES` for them, which are generated at runtime automatically;
- All deserialize of them are implemented manually without derive macro.