### PR TITLE
test!: run tests even some environment variables are not set

### DIFF
--- a/maa-cli/src/activity.rs
+++ b/maa-cli/src/activity.rs
@@ -212,6 +212,8 @@ impl<T, E: std::fmt::Display> WarnError<T> for std::result::Result<T, E> {
 mod tests {
     use super::*;
 
+    use std::env::var_os;
+
     #[test]
     fn parse_time_from_activity_info() {
         use chrono::{TimeZone, Utc};
@@ -441,21 +443,26 @@ mod tests {
     }
 
     #[test]
+    #[ignore = "need installed resource"]
     fn test_load_stage_activity() {
-        if std::env::var_os("MAA_CORE_INSTALLED").is_some() {
-            stage_activity().unwrap();
+        if var_os("SKIP_CORE_TEST").is_some() {
+            return;
         }
+        stage_activity().unwrap();
     }
 
     #[test]
+    #[ignore = "need installed resource"]
     fn test_item_index() {
-        if std::env::var_os("MAA_CORE_INSTALLED").is_some() {
-            load_item_index(ClientType::Official).unwrap();
-            load_item_index(ClientType::YoStarEN).unwrap();
-            load_item_index(ClientType::YoStarJP).unwrap();
-            load_item_index(ClientType::YoStarKR).unwrap();
-            load_item_index(ClientType::Txwy).unwrap();
+        if var_os("SKIP_CORE_TEST").is_some() {
+            return;
         }
+
+        load_item_index(ClientType::Official).unwrap();
+        load_item_index(ClientType::YoStarEN).unwrap();
+        load_item_index(ClientType::YoStarJP).unwrap();
+        load_item_index(ClientType::YoStarKR).unwrap();
+        load_item_index(ClientType::Txwy).unwrap();
     }
 
     #[test]

--- a/maa-cli/src/cleanup.rs
+++ b/maa-cli/src/cleanup.rs
@@ -184,7 +184,10 @@ mod tests {
 
     use crate::dirs::Ensure;
 
-    use std::{collections::BTreeSet, env::temp_dir};
+    use std::{
+        collections::BTreeSet,
+        env::{temp_dir, var_os},
+    };
 
     mod cleanup_target {
         use super::*;
@@ -278,8 +281,8 @@ mod tests {
             assert_should_keep!(CliCache, "copilot/", false);
 
             #[cfg(feature = "core_installer")]
-            if std::env::var_os("SKIP_CORE_TEST").is_none() {
-                let version = std::env::var_os("MAA_CORE_VERSION")
+            if var_os("SKIP_CORE_TEST").is_none() {
+                let version = var_os("MAA_CORE_VERSION")
                     .expect("MAA_CORE_VERSION environment variable not set");
                 let version = version.to_str().unwrap()[1..].parse().unwrap();
                 let name = crate::installer::maa_core::name(&version).unwrap();
@@ -395,7 +398,7 @@ mod tests {
     }
 
     #[test]
-    #[ignore]
+    #[ignore = "Need installed MaaCore and write to user directories"]
     fn test_cleanup_real_files() {
         // Create some files for testing
         cache().ensure().unwrap();
@@ -415,9 +418,11 @@ mod tests {
             ))
             .unwrap();
 
-            if let Some(version) = std::env::var_os("MAA_CORE_VERSION") {
-                let name =
-                    maa_core::name(&version.to_str().unwrap()[1..].parse().unwrap()).unwrap();
+            if var_os("SKIP_CORE_TEST").is_none() {
+                let version = var_os("MAA_CORE_VERSION")
+                    .expect("MAA_CORE_VERSION environment variable not set");
+                let version = version.to_str().unwrap()[1..].parse().unwrap();
+                let name = maa_core::name(&version).unwrap();
                 std::fs::File::create(join!(cache(), &name)).unwrap();
             }
         }

--- a/maa-cli/src/dirs.rs
+++ b/maa-cli/src/dirs.rs
@@ -529,7 +529,7 @@ mod tests {
             assert_eq!(resource(), test_dirs().resource());
             // The value of `MAA_COER_VERSION` is set in CI,
             // where the MaaCore is installed at standard location.
-            if env::var_os("MAA_CORE_INSTALLED").is_some() {
+            if env::var_os("SKIP_CORE_TEST").is_none() {
                 // This is not used in this test, but needed.
                 let extra_dir = Path::new("/usr/local/share/maa");
                 assert_eq!(

--- a/maa-cli/src/run/mod.rs
+++ b/maa-cli/src/run/mod.rs
@@ -305,10 +305,13 @@ mod tests {
     use std::env::{self, temp_dir};
 
     #[test]
+    #[ignore = "need installed MaaCore"]
     fn version() {
-        if let Some(version) = env::var_os("MAA_CORE_VERSION") {
-            assert_eq!(core_version().unwrap(), version);
+        if env::var_os("SKIP_VERSION_TEST").is_none() {
+            return;
         }
+        let version = env::var_os("MAA_CORE_VERSION").unwrap();
+        assert_eq!(core_version().unwrap(), version);
     }
 
     #[test]

--- a/maa-sys/src/lib.rs
+++ b/maa-sys/src/lib.rs
@@ -258,7 +258,7 @@ mod tests {
         let version = super::Assistant::get_version().unwrap();
 
         if let Some(v_str) = std::env::var_os("MAA_CORE_VERSION") {
-            assert_eq!(version, &v_str.to_str().unwrap()[1..]);
+            assert_eq!(version, v_str.to_str().unwrap());
         }
     }
 }

--- a/maa-sys/src/lib.rs
+++ b/maa-sys/src/lib.rs
@@ -255,6 +255,10 @@ mod tests {
     #[cfg(not(feature = "runtime"))]
     #[test]
     fn get_version() {
-        assert!(super::Assistant::get_version().is_ok());
+        let version = super::Assistant::get_version().unwrap();
+
+        if let Some(v_str) = std::env::var_os("MAA_CORE_VERSION") {
+            assert_eq!(version, v_str.to_str().unwrap()[1..]);
+        }
     }
 }

--- a/maa-sys/src/lib.rs
+++ b/maa-sys/src/lib.rs
@@ -258,7 +258,7 @@ mod tests {
         let version = super::Assistant::get_version().unwrap();
 
         if let Some(v_str) = std::env::var_os("MAA_CORE_VERSION") {
-            assert_eq!(version, v_str.to_str().unwrap()[1..]);
+            assert_eq!(version, &v_str.to_str().unwrap()[1..]);
         }
     }
 }


### PR DESCRIPTION
These tests are ignored. If run test with `--ignored`, they will be executed. To run these tests, installation of MaaCore and resource is needed, and some environment variables are needed to be set. If in some cases, these requirements are not met, use `SKIP_CORE_TEST` to skip.