### PR TITLE
fix: use ubuntu-22.04 instead of ubuntu-latest for build jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu-latest
+          - ubuntu-22.04
           - macos-13 # x86_64 runner
           - macos-latest # aarch64 runner
           - windows-latest
@@ -94,7 +94,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu-latest
+          - ubuntu-22.04
           - windows-latest
     steps:
       - name: Checkout
@@ -116,7 +116,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu-latest
+          - ubuntu-22.04
           - macos-latest
           - windows-latest
         feature:
@@ -142,7 +142,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu-latest
+          - ubuntu-22.04
           - macos-13 # x86_64 runner
           - macos-latest # aarch64 runner
           - windows-latest
@@ -174,7 +174,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu-latest
+          - ubuntu-22.04
           - macos-latest # aarch64 runner
           - windows-latest
     env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -109,7 +109,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu-latest
+          - ubuntu-22.04
           - windows-latest
         host-arch:
           - x86_64


### PR DESCRIPTION
The `ubuntu-latest` runner is currently based on Ubuntu 24.04, which has higher version of `glibc` than some users' systems.

Fixes: #358 