### PR TITLE
ci: improve test jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,7 @@ jobs:
           cargo test -- --include-ignored
 
   build-cross:
-    name: Cross Build to aarch64
+    name: Cross Build
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -110,7 +110,7 @@ jobs:
             --features vendored-openssl
 
   build-no-default-features:
-    name: Build and Test (features=${{ matrix.feature }})
+    name: Build and Test (${{ matrix.feature }})
     runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
@@ -130,7 +130,7 @@ jobs:
             -- --include-ignored
 
   build-sys:
-    name: Build and Test (maa-sys, static)
+    name: Build and Test (maa-sys, static, ${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,14 +53,14 @@ jobs:
         uses: Swatinem/rust-cache@v2
       - name: Build (maa-cli)
         run: |
-          cargo build --package maa-cli --locked
+          cargo build --locked
       - name: Lint (clippy)
         run: |
-          cargo clippy --package maa-cli -- -D warnings
+          cargo clippy -- -D warnings
       - name: Lint (rustfmt)
         run: |
-          rustup toolchain install nightly -c rustfmt
-          cargo +nightly fmt --package maa-cli -- --check
+          rustup toolchain install nightly --profile minimal --component rustfmt
+          cargo +nightly fmt -- --check
       - name: Install MaaCore
         env:
           MAA_CONFIG_DIR: ${{ github.workspace }}/crates/maa-cli/config_examples
@@ -109,8 +109,8 @@ jobs:
           cargo build --package maa-cli --locked \
             --features vendored-openssl
 
-  build-no-default:
-    name: No Default Build
+  build-no-default-features:
+    name: Build and Test (features=${{ matrix.feature }})
     runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
@@ -121,15 +121,13 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-      - name: Build
-        run: |
-          cargo build --package maa-cli --locked \
-            --no-default-features --features '${{ matrix.feature }}'
-      - name: Test
+      - name: Build and Test
         env:
           SKIP_CORE_TEST: true
         run: |
-          cargo test -- --include-ignored
+          cargo test --package maa-cli --locked
+            --no-default-features --features '${{ matrix.feature }}' \
+            -- --include-ignored
 
   build-sys:
     name: Build and Test (maa-sys, static)
@@ -153,7 +151,7 @@ jobs:
         run: cargo clippy --package maa-sys -- -D warnings
       - name: Lint (fmt)
         run: |
-          rustup toolchain install nightly -c rustfmt
+          rustup toolchain install nightly --profile minimal --component rustfmt
           cargo +nightly fmt --package maa-sys -- --check
       - name: Test
         # It seems rust needs a static library to check the linking.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,7 +125,7 @@ jobs:
         env:
           SKIP_CORE_TEST: true
         run: |
-          cargo test --package maa-cli --locked
+          cargo test --package maa-cli --locked \
             --no-default-features --features '${{ matrix.feature }}' \
             -- --include-ignored
 

--- a/crates/maa-cli/src/config/cli/mod.rs
+++ b/crates/maa-cli/src/config/cli/mod.rs
@@ -213,6 +213,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "git2")]
     fn deserialize_example() {
         let config: CLIConfig =
             toml::from_str(&std::fs::read_to_string("./config_examples/cli.toml").unwrap())

--- a/crates/maa-cli/src/config/cli/mod.rs
+++ b/crates/maa-cli/src/config/cli/mod.rs
@@ -179,6 +179,7 @@ mod tests {
             ],
         );
 
+        #[cfg(feature = "git2")]
         assert_de_tokens(
             &CLIConfig {
                 resource: resource::tests::example_config(),

--- a/crates/maa-cli/src/config/cli/resource.rs
+++ b/crates/maa-cli/src/config/cli/resource.rs
@@ -321,6 +321,7 @@ impl Remote {
 pub mod tests {
     use super::*;
 
+    #[cfg(feature = "git2")]
     pub fn example_config() -> Config {
         Config {
             auto_update: true,


### PR DESCRIPTION
- Run tests for all packages in main test job;
- Make sure run test with no default features in no default build job;
- Minimize installation of nightly version rustfmt.