### PR TITLE
feat: add `warn_on_update_failure` option for hot update

### DIFF
--- a/crates/maa-cli/config_examples/cli.toml
+++ b/crates/maa-cli/config_examples/cli.toml
@@ -34,14 +34,15 @@ binary = false # Whether to install binary of maa-cli
 # while this is hot update resource of MaaCore
 # You cannot use this to hot update without any base resource
 [resource]
-auto_update = true  # Whether to auto update resource each time run maa task
-backend = "libgit2" # Backend to manipulate repository, can be `git` or `libgit2`
+auto_update = true            # Whether to auto update resource each time run maa task
+warn_on_update_failure = true # Whether to warn on update failure instead of panic
+backend = "libgit2"           # Backend to manipulate repository, can be `git` or `libgit2`
 
 # Configurations for remote git repository of resource
 [resource.remote]
 branch = "main" # Branch of remote resource repository
 # URL of remote resource repository, leave it empty to use the default URL
-uril = "https://github.com/MaaAssistantArknights/MaaResource.git"
+url = "https://github.com/MaaAssistantArknights/MaaResource.git"
 # Or you can use ssh to clone the repository
 # url = "git@github.com:MaaAssistantArknights/MaaResource.git"
 # If you want to use ssh, a certificate is needed which can be "ssh-agent" or "ssh-key"

--- a/crates/maa-cli/docs/en-US/config.md
+++ b/crates/maa-cli/docs/en-US/config.md
@@ -413,6 +413,7 @@ binary = true # whether install maa-cli binary
 # hot update resource configurations
 [resource]
 auto_update = true # whether auto update resource before running task
+warn_on_update_failure = true # Whether to warn on update failure instead of panic
 backend = "libgit2" # the backend of resource, can be "libgit2" or "git"
 
 # the remote of resource

--- a/crates/maa-cli/docs/ja-JP/config.md
+++ b/crates/maa-cli/docs/ja-JP/config.md
@@ -403,6 +403,7 @@ binary = true # 是否安装 maa-cli 的二进制文件，默认为 true
 # 资源热更新相关配置
 [resource]
 auto_update = true  # 是否在每次运行任务时自动更新资源，默认为 false
+warn_on_update_failure = true # 是否在更新失败时发出警告而不是直接报错
 backend = "libgit2" # 资源热更新后端，可选值为 "git" 或者 "libgit2"，默认为 "git"
 
 # 资源热更新远程仓库相关配置

--- a/crates/maa-cli/docs/ko-KR/config.md
+++ b/crates/maa-cli/docs/ko-KR/config.md
@@ -396,6 +396,7 @@ binary = true # maa-cli 바이너리 파일을 설치할지 여부, 기본값은
 # 리소스 핫 업데이트 관련 설정
 [resource]
 auto_update = true  # 각 작업 실행 시 리소스를 자동 업데이트할지 여부, 기본값은 false
+warn_on_update_failure = true # 업데이트 실패 시 오류를 바로 보고하지 않고 경고를 발행할지 여부
 backend = "libgit2" # 리소스 핫 업데이트 백엔드, 가능한 값은 "git" 또는 "libgit2", 기본값은 "git"
 
 [resource.remote]

--- a/crates/maa-cli/docs/zh-CN/config.md
+++ b/crates/maa-cli/docs/zh-CN/config.md
@@ -399,6 +399,7 @@ binary = true # 是否安装 maa-cli 的二进制文件，默认为 true
 # 资源热更新相关配置
 [resource]
 auto_update = true  # 是否在每次运行任务时自动更新资源，默认为 false
+warn_on_update_failure = true # 是否在更新失败时发出警告而不是直接报错
 backend = "libgit2" # 资源热更新后端，可选值为 "git" 或者 "libgit2"，默认为 "git"
 
 # 资源热更新远程仓库相关配置

--- a/crates/maa-cli/docs/zh-TW/config.md
+++ b/crates/maa-cli/docs/zh-TW/config.md
@@ -403,6 +403,7 @@ binary = true # 是否安装 maa-cli 的二进制文件，默认为 true
 # 资源热更新相关配置
 [resource]
 auto_update = true  # 是否在每次运行任务时自动更新资源，默认为 false
+warn_on_update_failure = true # 是否在更新失败时发出警告而不是直接报错
 backend = "libgit2" # 资源热更新后端，可选值为 "git" 或者 "libgit2"，默认为 "git"
 
 # 资源热更新远程仓库相关配置

--- a/crates/maa-cli/schemas/cli.schema.json
+++ b/crates/maa-cli/schemas/cli.schema.json
@@ -36,6 +36,7 @@
       "type": "object",
       "properties": {
         "auto_update": { "type": "boolean" },
+        "warn_on_update_failure": { "type": "boolean" },
         "backend": { "type": "string", "enum": ["git", "libgit2"] },
         "remote": {
           "type": "object",

--- a/crates/maa-cli/src/config/cli/mod.rs
+++ b/crates/maa-cli/src/config/cli/mod.rs
@@ -191,6 +191,8 @@ mod tests {
                 Token::Map { len: Some(3) },
                 Token::Str("auto_update"),
                 Token::Bool(true),
+                Token::Str("warn_on_update_failure"),
+                Token::Bool(true),
                 Token::Str("backend"),
                 GitBackend::Libgit2.to_token(),
                 Token::Str("remote"),

--- a/crates/maa-cli/src/config/cli/resource.rs
+++ b/crates/maa-cli/src/config/cli/resource.rs
@@ -8,13 +8,16 @@ use crate::value::userinput::{Input, UserInput};
 #[cfg_attr(test, derive(Debug, PartialEq))]
 #[derive(Deserialize, Default, Clone)]
 pub struct Config {
+    /// Automatically update resource every time
     #[serde(default)]
     auto_update: bool,
-    /// Warn on auto update failure instead of exiting
+    /// Warn on update failure instead of exiting
     #[serde(default)]
     warn_on_update_failure: bool,
+    /// Backend to use for resource update
     #[serde(default)]
     backend: GitBackend,
+    /// Remote configuration for resource update
     #[serde(default)]
     remote: Remote,
 }
@@ -358,6 +361,17 @@ pub mod tests {
                 certificate: None,
             }
         });
+    }
+
+    #[test]
+    fn getter() {
+        let config = Config::default();
+        assert!(!config.auto_update());
+        assert!(!config.warn_on_update_failure());
+        assert_eq!(config.backend(), GitBackend::Git);
+        assert_eq!(config.remote().url(), default_url());
+        assert_eq!(config.remote().branch(), None);
+        assert_eq!(config.remote().certificate(), None);
     }
 
     mod serde {

--- a/crates/maa-cli/src/config/cli/resource.rs
+++ b/crates/maa-cli/src/config/cli/resource.rs
@@ -10,6 +10,9 @@ use crate::value::userinput::{Input, UserInput};
 pub struct Config {
     #[serde(default)]
     auto_update: bool,
+    /// Warn on auto update failure instead of exiting
+    #[serde(default)]
+    warn_on_update_failure: bool,
     #[serde(default)]
     backend: GitBackend,
     #[serde(default)]
@@ -19,6 +22,10 @@ pub struct Config {
 impl Config {
     pub fn auto_update(&self) -> bool {
         self.auto_update
+    }
+
+    pub fn warn_on_update_failure(&self) -> bool {
+        self.warn_on_update_failure
     }
 
     pub fn backend(&self) -> GitBackend {
@@ -325,6 +332,7 @@ pub mod tests {
     pub fn example_config() -> Config {
         Config {
             auto_update: true,
+            warn_on_update_failure: true,
             backend: GitBackend::Libgit2,
             remote: Remote {
                 url: String::from("https://github.com/MaaAssistantArknights/MaaResource.git"),
@@ -342,6 +350,7 @@ pub mod tests {
         let config = Config::default();
         assert_eq!(config, Config {
             auto_update: false,
+            warn_on_update_failure: false,
             backend: GitBackend::Git,
             remote: Remote {
                 url: default_url(),
@@ -550,6 +559,7 @@ pub mod tests {
             assert_de_tokens(
                 &Config {
                     auto_update: true,
+                    warn_on_update_failure: true,
                     backend: GitBackend::Git,
                     remote: Remote {
                         url: String::from("git@github.com:MaaAssistantArknights/MaaResource.git"),
@@ -561,8 +571,10 @@ pub mod tests {
                     },
                 },
                 &[
-                    Token::Map { len: Some(3) },
+                    Token::Map { len: Some(4) },
                     Token::Str("auto_update"),
+                    Token::Bool(true),
+                    Token::Str("warn_on_update_failure"),
                     Token::Bool(true),
                     Token::Str("backend"),
                     GitBackend::Git.to_token(),


### PR DESCRIPTION
When the `warn_on_update_failure` option is enabled, maa will warn the user when the hot update fails instead of panicking.

Closes #371 