### PR TITLE
fix: use `txwy` instead of `Txwy` when init

### DIFF
--- a/crates/maa-cli/src/config/init.rs
+++ b/crates/maa-cli/src/config/init.rs
@@ -96,7 +96,7 @@ fn asst_config_template() -> MAAValue {
                         Some("resource for English client"),
                     ),
                     ValueWithDesc::new(
-                        "Txwy",
+                        "txwy",
                         Some("resource for Traditional Chinese client"),
                     ),
                 ],


### PR DESCRIPTION
I noticed that the corresponding field in `schemas/asst.schema.json` is `txwy`, not `Txwy`.

And when using `Txwy`, it results in a "Global resource Txwy not found" warnning. But in fact, we do have a resource at `.local/share/maa/resource/global/txwy/resource`. 

Therefore, I believe using `txwy` instead of `Txwy` during initialization is the correct approach.