### PR TITLE
ci: replace `macos-13` with `macos-15-intel`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
       matrix:
         os:
           - ubuntu-22.04
-          - macos-13 # x86_64 runner
+          - macos-15-intel # x86_64 runner
           - macos-latest # aarch64 runner
           - windows-latest
     env:
@@ -151,7 +151,7 @@ jobs:
       matrix:
         os:
           - ubuntu-22.04
-          - macos-13 # x86_64 runner
+          - macos-15-intel # x86_64 runner
           - macos-latest # aarch64 runner
           - windows-latest
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -118,7 +118,7 @@ jobs:
           - aarch64
         # macOS can be natively built on both x86_64 and aarch64
         include:
-          - os: macos-13
+          - os: macos-15-intel
             target-arch: x86_64
           - os: macos-latest
             target-arch: aarch64


### PR DESCRIPTION
## Summary by Sourcery

将 CI 和发布工作流中的 x86_64 macOS 任务，从 macos-13 更新为使用 macos-15-intel 运行器。

CI：
- 将 CI 矩阵中的 x86_64 macOS 任务由 macos-13 切换为 macos-15-intel。

Deployment：
- 调整发布工作流的构建矩阵，使 x86_64 macOS 构建目标为 macos-15-intel。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update CI and release workflows to use the macos-15-intel runner instead of macos-13 for x86_64 macOS jobs.

CI:
- Switch CI matrix x86_64 macOS jobs from macos-13 to macos-15-intel.

Deployment:
- Adjust release workflow build matrix to target macos-15-intel for x86_64 macOS builds.

</details>