### PR TITLE
feat: support report callback

### DIFF
--- a/crates/maa-cli/src/run/callback/mod.rs
+++ b/crates/maa-cli/src/run/callback/mod.rs
@@ -608,11 +608,9 @@ fn process_report(message: &Map<String, Value>) -> Option<()> {
     let body = message.get("body")?.as_str()?;
     let headers = message.get("headers")?.as_object()?;
 
-    debug!("Reporting to Penguin Stats: {}", url);
+    info!("{subtask}: {url}");
 
-    let mut request = crate::state::AGENT
-        .post(url)
-        .content_type("application/json");
+    let mut request = ureq::post(url).content_type("application/json");
 
     for (key, value) in headers {
         if let Some(value_str) = value.as_str() {
@@ -629,7 +627,7 @@ fn process_report(message: &Map<String, Value>) -> Option<()> {
                 warn!("Failed to {subtask}: HTTP {status}");
             }
         }
-        Err(e) => error!("Failed to {subtask}: {e}"),
+        Err(e) => warn!("Failed to {subtask}: {e}"),
     }
 
     Some(())


### PR DESCRIPTION
Fixes #432

## Summary by Sourcery

添加对处理外部报告回调消息并将其转发为 HTTP 请求的支持。

新特性：
- 处理用于外部回调的新的 `ReportRequest` 助手消息类型。
- 根据报告回调数据发送带有 JSON 请求体和自定义请求头的 HTTP POST 请求。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add support for handling external report callback messages and forwarding them as HTTP requests.

New Features:
- Handle a new ReportRequest assistant message type for external callbacks.
- Send HTTP POST requests with JSON bodies and custom headers based on report callback data.

</details>