### PR TITLE
docs: Add docs tip for winget users to use maa-cli command name

### DIFF
--- a/crates/maa-cli/docs/zh-CN/usage.md
+++ b/crates/maa-cli/docs/zh-CN/usage.md
@@ -7,7 +7,7 @@ maa-cli 主要功能是通过调用 MaaCore，自动化完成明日方舟的游�
 对于使用 Windows 包管理器 (winget) 安装 maa-cli 的用户，以下命令中的 `maa` 需要替换为 `maa-cli` 。
 
 :::
- 
+
 ## 管理 MaaCore
 
 maa-cli 可以安装和更新 MaaCore 及资源，只需运行以下命令：


### PR DESCRIPTION
Add usage tips for Windows package manager users.

## Summary by Sourcery

文档：
- 在中文使用文档中添加一个提示，说明使用 winget 安装时，在示例中应使用 `maa-cli` 作为命令名称，而不是 `maa`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Add a tip in the Chinese usage documentation explaining that winget installations should use the `maa-cli` command name instead of `maa` in examples.

</details>
- 新增提示，说明通过 winget 安装的用户在参考文档示例时，应使用命令名 `maa-cli` 而不是 `maa`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

文档：
- 在中文使用文档中添加一个提示，说明使用 winget 安装时，在示例中应使用 `maa-cli` 作为命令名称，而不是 `maa`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Add a tip in the Chinese usage documentation explaining that winget installations should use the `maa-cli` command name instead of `maa` in examples.

</details>

</details>