### PR TITLE
fix: adapt to callback changes

### DIFF
--- a/crates/maa-cli/src/run/callback/mod.rs
+++ b/crates/maa-cli/src/run/callback/mod.rs
@@ -328,7 +328,7 @@ fn process_subtask_start(message: &Map<String, Value>) -> Option<()> {
             }
             "StageTraderEnter" => info!("{}", "StageTraderEnter"),
             "StageSafeHouseEnter" => info!("{}", "StageSafeHouseEnter"),
-            "StageCambatOpsEnter" | "StageCambatDpsEnter" => info!("{}", "StageCambatOpsEnter"),
+            "StageCombatOpsEnter" | "StageCombatDpsEnter" => info!("{}", "StageCombatOpsEnter"),
             "StageEmergencyOps" | "StageEmergencyDps" => info!("{}", "EmergencyOpsEnter"),
             "StageDreadfulFoe" | "StageDreadfulFoe-5Enter" => info!("{}", "DreadfulFoe"),
             "StageTraderInvestSystemFull" => warn!("{}", "TraderInvestSystemFull"),


### PR DESCRIPTION
See MaaAssistantArknights/MaaAssistantArknights#15325

## Summary by Sourcery

错误修复：
- 兼容旧版和新版类Roguelike关卡的回调事件名称，适用于战斗关卡和紧急作战关卡。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Handle both legacy and new roguelike stage callback event names for combat and emergency operations stages.

</details>