### PR TITLE
feat: print log dir on MAAError

### DIFF
--- a/crates/maa-cli/src/run/mod.rs
+++ b/crates/maa-cli/src/run/mod.rs
@@ -17,7 +17,7 @@ use anyhow::{Context, Result, bail};
 use clap::Args;
 use log::{debug, warn};
 use maa_dirs::{self as dirs, Ensure, MAA_CORE_LIB};
-use maa_sys::{Assistant, Error};
+use maa_sys::Assistant;
 use signal_hook::consts::TERM_SIGNALS;
 
 use crate::{
@@ -242,16 +242,6 @@ where
     let ret = run_core(f, args);
 
     summary::display();
-
-    if let Err(error) = &ret
-        && let Some(Error::MAAError) = error.downcast_ref()
-    {
-        // A friendlier message for this case
-        bail!(
-            "MaaCore returned an error, check its log ({}) for details",
-            dirs::log().join("asst.log").display()
-        );
-    }
 
     ret?;
 


### PR DESCRIPTION
When MaaCore returned an error, maa-cli printed a bare message

```
MaaCore returned an error, check its log for details
```

and I had no idea where the log was. While one can always find it with `maa dir log`, it is perhaps more user-friendly to print the path of the log file when this error occurs.

## Summary by Sourcery

当 MaaCore 返回错误时，打印 MaaCore 日志文件路径。

New Features:
- 在 MAAError 错误消息中包含 MaaCore 日志文件路径，以便更容易找到日志。

Enhancements:
- 在进程内跟踪助手用户目录，以在发生错误时构造 MaaCore 日志文件路径。

Tests:
- 更新现有的 maa-sys 错误处理测试，以适应 MAAError 现在携带日志文件路径的情况。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Print MaaCore log file path when MaaCore returns an error.

New Features:
- Include MaaCore log file path in MAAError error messages for easier log discovery.

Enhancements:
- Track the assistant user directory in-process to construct MaaCore log file paths when errors occur.

Tests:
- Update existing maa-sys error handling tests to account for MAAError now carrying a log file path.

</details>
- 当返回 `MAAError` 时，在错误消息中打印 MaaCore 日志文件路径。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

当 MaaCore 返回错误时，打印 MaaCore 日志文件路径。

New Features:
- 在 MAAError 错误消息中包含 MaaCore 日志文件路径，以便更容易找到日志。

Enhancements:
- 在进程内跟踪助手用户目录，以在发生错误时构造 MaaCore 日志文件路径。

Tests:
- 更新现有的 maa-sys 错误处理测试，以适应 MAAError 现在携带日志文件路径的情况。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Print MaaCore log file path when MaaCore returns an error.

New Features:
- Include MaaCore log file path in MAAError error messages for easier log discovery.

Enhancements:
- Track the assistant user directory in-process to construct MaaCore log file paths when errors occur.

Tests:
- Update existing maa-sys error handling tests to account for MAAError now carrying a log file path.

</details>

</details>