### PR TITLE
pref: simplify git clone command construction

### DIFF
--- a/crates/maa-cli/src/installer/resource.rs
+++ b/crates/maa-cli/src/installer/resource.rs
@@ -146,12 +146,8 @@ mod git {
     ) -> Result<()> {
         let mut cmd = std::process::Command::new("git");
 
-        cmd.args([
-            "clone",
-            url,
-            dest.to_str().context("Invalid path")?,
-            "--depth=1",
-        ]);
+        cmd.args(["clone", "--depth=1", url]);
+        cmd.arg(dest);
 
         if let Some(branch) = branch {
             cmd.args(["--branch", branch]);


### PR DESCRIPTION
## Summary by Sourcery

增强内容：
- 调整 `git clone` 参数顺序和路径处理方式，改为依赖 `Command` 的类型化参数方法，而不是将目标路径转换为字符串。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Adjust git clone argument ordering and path handling to rely on Command’s typed argument methods instead of converting the destination path to a string.

</details>