### PR TITLE
feat: use simplified UA for HTTP requests

### DIFF
--- a/crates/maa-cli/src/run/callback/mod.rs
+++ b/crates/maa-cli/src/run/callback/mod.rs
@@ -6,6 +6,8 @@ use maa_types::primitive::{AsstMsgId, AsstTaskId};
 use serde_json::{Map, Value};
 use summary::{edit_current_task_detail, end_current_task, start_task};
 
+use crate::state::AGENT;
+
 pub static MAA_CORE_ERRORED: AtomicBool = AtomicBool::new(false);
 
 pub unsafe extern "C" fn default_callback(
@@ -610,7 +612,7 @@ fn process_report(message: &Map<String, Value>) -> Option<()> {
 
     info!("{subtask}: {url}");
 
-    let mut request = ureq::post(url).content_type("application/json");
+    let mut request = AGENT.post(url).content_type("application/json");
 
     for (key, value) in headers {
         if let Some(value_str) = value.as_str() {

--- a/crates/maa-cli/src/state.rs
+++ b/crates/maa-cli/src/state.rs
@@ -1,9 +1,6 @@
 //! Module for managing the global state of the maa-cli.
 
-use std::{
-    env::consts::{ARCH, OS},
-    sync::LazyLock,
-};
+use std::sync::LazyLock;
 
 use semver::Version;
 use ureq::{
@@ -27,16 +24,13 @@ pub static CORE_VERSION: LazyLock<Option<Version>> = LazyLock::new(|| {
 });
 
 pub static AGENT: LazyLock<Agent> = LazyLock::new(|| {
-    let core_version_str = CORE_VERSION_STR.as_deref().unwrap_or("Unknown");
     Agent::config_builder()
         .tls_config(
             TlsConfig::builder()
                 .root_certs(RootCerts::PlatformVerifier)
                 .build(),
         )
-        .user_agent(format!(
-            "maa-cli/{CLI_VERSION_STR} ({OS}; {ARCH}) libMaaCore/{core_version_str}"
-        ))
+        .user_agent(format!("maa-cli/{CLI_VERSION_STR}"))
         .build()
         .into()
 });


### PR DESCRIPTION
## Summary by Sourcery

简化 maa-cli 使用的 HTTP User-Agent，并通过共享配置的 HTTP 代理发送 JSON POST 请求。

改进内容：
- 为通过共享代理发出的所有 HTTP 请求使用精简的、仅用于 maa-cli 的 User-Agent 字符串。
- 更新回调上报逻辑，将 JSON POST 请求改为使用集中化的 `AGENT` 配置发送，而不是手动构造原始的 `ureq` 请求。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Simplify the HTTP user agent used by maa-cli and route JSON POST requests through the shared configured HTTP agent.

Enhancements:
- Use a shortened maa-cli-only user agent string for all HTTP requests made via the shared agent.
- Update callback reporting to send JSON POST requests using the centralized AGENT configuration instead of constructing raw ureq requests.

</details>