### PR TITLE
fix(copilot): single-task copilot uses `filename` instead of `copilot_list`

### DIFF
--- a/crates/maa-cli/src/run/preset/copilot.rs
+++ b/crates/maa-cli/src/run/preset/copilot.rs
@@ -230,7 +230,7 @@ impl IntoParameters for CopilotParams {
                 .next()
                 .expect("single-file mode requires exactly one copilot stage");
             insert!(params,
-                "filename" => stage_opt.filename.to_string_lossy().to_string()
+                "filename" => stage_opt.filename?
             );
         } else {
             insert!(params,


### PR DESCRIPTION
当只有一个 copilot 作业（且 --raid != 2）时传递 `filename`，多个作业仍使用 `copilot_list`。以此修复像 剿灭作战 这类需在右下角有 “开始作战” 界面启动任务却因为战斗列表尝试进行导航而无法启动的问题。

## Summary by Sourcery

调整 copilot 预设参数的生成逻辑：对于单个且非 raid 模式的任务，使用单文件模式，并相应更新测试。

Bug Fixes:
- 修复单任务 copilot 运行问题：当仅配置一个 job 且 raid 模式不为 2 时，通过传递顶层的 filename 参数而不是 copilot_list。

Tests:
- 更新 copilot 预设测试，用于在单任务场景下断言基于 filename 的参数。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust copilot preset parameter generation to use single-file mode for a single non-raid task and update tests accordingly.

Bug Fixes:
- Fix single-task copilot runs by passing a top-level filename parameter instead of a copilot_list when only one job is configured and raid mode is not 2.

Tests:
- Update copilot preset tests to assert filename-based parameters for single-task scenarios.

</details>