### PR TITLE
refactor: remove log path from maa-core errors

### DIFF
--- a/crates/maa-core/src/error.rs
+++ b/crates/maa-core/src/error.rs
@@ -2,8 +2,8 @@ use maa_ffi_types::{AsstBool, AsstId, AsstSize};
 
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
-    #[error("MaaCore returned an error, check its log ({0}) for details")]
-    MAAError(std::path::PathBuf),
+    #[error("MaaCore returned an error")]
+    MAAError,
     #[error("Failed to create Assistant")]
     NullHandle,
     #[error("Buffer too small")]
@@ -25,16 +25,15 @@ pub enum Error {
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 
 /// Specific error produced when an `AsstBool` or `AsstId` FFI call returns its
-/// failure sentinel. Carries the path to MaaCore's log file so callers can
-/// direct users to it for diagnosis.
+/// failure sentinel.
 ///
 /// Converts to [`Error::MAAError`] via `From`.
 #[derive(Debug)]
-pub(crate) struct MaaCoreError(pub(crate) std::path::PathBuf);
+pub(crate) struct MaaCoreError;
 
 impl From<MaaCoreError> for Error {
-    fn from(e: MaaCoreError) -> Self {
-        Error::MAAError(e.0)
+    fn from(_: MaaCoreError) -> Self {
+        Error::MAAError
     }
 }
 
@@ -97,11 +96,7 @@ impl AsstResult for AsstBool {
     type Return = ();
 
     fn to_result(self) -> std::result::Result<(), MaaCoreError> {
-        if self == 1 {
-            Ok(())
-        } else {
-            Err(MaaCoreError(crate::get_log_path()))
-        }
+        if self == 1 { Ok(()) } else { Err(MaaCoreError) }
     }
 }
 
@@ -124,7 +119,7 @@ impl AsstResult for AsstId {
 
     fn to_result(self) -> std::result::Result<AsstId, MaaCoreError> {
         if self == INVALID_ID {
-            Err(MaaCoreError(crate::get_log_path()))
+            Err(MaaCoreError)
         } else {
             Ok(self)
         }
@@ -138,12 +133,12 @@ mod tests {
 
     #[test]
     fn asst_bool() {
-        assert!(matches!(0u8.to_result(), Err(MaaCoreError(_))));
+        assert!(matches!(0u8.to_result(), Err(MaaCoreError)));
         assert!(matches!(1u8.to_result(), Ok(())));
         // to_maa_result: Ok path
         assert!(1u8.to_maa_result().is_ok());
         // to_maa_result: Err path exercises From<MaaCoreError>
-        assert!(matches!(0u8.to_maa_result(), Err(Error::MAAError(_))));
+        assert!(matches!(0u8.to_maa_result(), Err(Error::MAAError)));
     }
 
     #[test]
@@ -162,13 +157,10 @@ mod tests {
 
     #[test]
     fn asst_id() {
-        assert!(matches!(INVALID_ID.to_result(), Err(MaaCoreError(_))));
+        assert!(matches!(INVALID_ID.to_result(), Err(MaaCoreError)));
         assert_eq!(1i32.to_result().unwrap(), 1i32);
         // to_maa_result: Err path
-        assert!(matches!(
-            INVALID_ID.to_maa_result(),
-            Err(Error::MAAError(_))
-        ));
+        assert!(matches!(INVALID_ID.to_maa_result(), Err(Error::MAAError)));
         assert_eq!(1i32.to_maa_result().unwrap(), 1i32);
     }
 }

--- a/crates/maa-core/src/lib.rs
+++ b/crates/maa-core/src/lib.rs
@@ -1,9 +1,6 @@
 #![cfg_attr(coverage_nightly, feature(coverage_attribute))]
 
-use std::{
-    ffi::{c_char, c_void},
-    sync::RwLock,
-};
+use std::ffi::{c_char, c_void};
 
 use maa_ffi_string::ToCString;
 use maa_ffi_types::*;
@@ -16,17 +13,6 @@ use callback::trampoline;
 mod error;
 use error::{AsstResult, BufferTooSmall};
 pub use error::{Error, Result};
-
-/// The user directory of the assistant.
-static USER_DIR: RwLock<std::path::PathBuf> = RwLock::new(std::path::PathBuf::new());
-
-/// Get the path of MaaCore's log file.
-///
-/// For use with `Error::MAAError`.
-pub(crate) fn get_log_path() -> std::path::PathBuf {
-    // Unwrap: The RwLock only errors if it is poisoned, which should never happen.
-    USER_DIR.read().unwrap().join("debug").join("asst.log")
-}
 
 /// A safe and convenient wrapper of MaaCore Assistant API.
 ///
@@ -116,9 +102,6 @@ impl Assistant {
     pub fn set_user_dir(path: impl ToCString) -> Result<()> {
         let cstring = path.to_cstring()?;
         unsafe { maa_sys::binding::AsstSetUserDir(cstring.as_ptr()) }.to_maa_result()?;
-        let path_buf = std::path::PathBuf::from(cstring.to_string_lossy().as_ref());
-        // Unwrap: The RwLock only errors if it is poisoned, which should never happen.
-        *USER_DIR.write().unwrap() = path_buf;
         Ok(())
     }
 


### PR DESCRIPTION
## Summary
- remove the log path payload from `maa-core::Error::MAAError`
- drop the internal `USER_DIR` state that only existed to build that path
- keep `maa-core` focused on FFI failure signals instead of execution-layer diagnostics

## Verification
- `cargo +nightly fmt`
- `cargo test -p maa-core`
- `cargo clippy -p maa-core --tests -- -D warnings`
- `cargo x test`

## Note
- `cargo x test --no-clippy` still hits the existing xtask forwarding bug in this branch

## Summary by Sourcery

通过移除对日志文件路径和内部用户目录状态的依赖，简化 maa-core 在 MaaCore FFI 失败场景下的错误处理。

增强内容：
- 从 MaaCore 错误变体中移除日志文件路径载荷，使 maa-core 专注于 FFI 失败信号本身，而非诊断信息。
- 移除全局的 `USER_DIR` 状态及其相关的日志路径辅助方法，因为错误类型中不再携带日志位置。

测试：
- 更新 maa-core 测试，用于断言新的、简化后的 MaaCore 错误结构（不再包含日志路径数据）。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Simplify maa-core error handling for MaaCore FFI failures by removing dependence on log file paths and internal user directory state.

Enhancements:
- Remove log file path payload from MaaCore error variants to keep maa-core focused on FFI failure signaling rather than diagnostics.
- Eliminate the global USER_DIR state and associated log-path helper now that errors no longer carry log locations.

Tests:
- Update maa-core tests to assert the new, simplified MaaCore error shape without log path data.

</details>