### PR TITLE
feat: add a blanket impl for ValueWithDesc

### DIFF
--- a/crates/maa-question/src/question/select.rs
+++ b/crates/maa-question/src/question/select.rs
@@ -235,6 +235,38 @@ pub trait Selectable {
     fn parse(input: &str) -> Result<Self::Value, Self::Error>;
 }
 
+/// A helper macro to implement [`Selectable`] for a type that implements [`FromStr`].
+///
+///
+/// As rust don't support specialization, we cannot use a blanket implementation for
+/// any type that implements [`FromStr`].
+macro_rules! impl_selectable {
+    ($type:path) => {
+        impl Selectable for $type {
+            type Error = <$type as FromStr>::Err;
+            type Value = $type;
+
+            fn value(self) -> $type {
+                self
+            }
+
+            fn parse(input: &str) -> Result<$type, Self::Error> {
+                input.parse()
+            }
+        }
+    };
+    ($($type:path),*) => {
+        $(
+            impl_selectable!($type);
+        )*
+    };
+}
+
+impl_selectable!(i8, i16, i32, i64, isize);
+impl_selectable!(u8, u16, u32, u64, usize);
+impl_selectable!(f32, f64);
+impl_selectable!(String, std::path::PathBuf);
+
 #[derive(Clone, PartialEq, Debug)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "serde", derive(Deserialize))]
@@ -244,7 +276,7 @@ pub enum ValueWithDesc<T> {
     WithDesc { value: T, desc: String },
 }
 
-impl<T: Display> ValueWithDesc<T> {
+impl<T> ValueWithDesc<T> {
     pub fn new(value: impl Into<T>, desc: Option<&str>) -> Self {
         match desc {
             Some(desc) => Self::WithDesc {
@@ -263,30 +295,6 @@ impl<T: Display> ValueWithDesc<T> {
         }
     }
 }
-
-macro_rules! impl_selectable {
-    ($type:ty) => {
-        impl Selectable for $type {
-            type Error = <$type as FromStr>::Err;
-            type Value = $type;
-
-            fn value(self) -> $type {
-                self
-            }
-
-            fn parse(input: &str) -> Result<$type, Self::Error> {
-                input.parse()
-            }
-        }
-    };
-    ($($type:ty),*) => {
-        $(
-            impl_selectable!($type);
-        )*
-    };
-}
-
-impl_selectable!(i32, f32, String);
 
 impl<T> From<T> for ValueWithDesc<T> {
     fn from(value: T) -> Self {
@@ -309,7 +317,7 @@ impl<T: Display> Display for ValueWithDesc<T> {
     }
 }
 
-impl<T: Selectable + Display> Selectable for ValueWithDesc<T> {
+impl<T: Selectable> Selectable for ValueWithDesc<T> {
     type Error = T::Error;
     type Value = T::Value;
 

--- a/crates/maa-question/src/question/select.rs
+++ b/crates/maa-question/src/question/select.rs
@@ -1,5 +1,4 @@
 use std::{
-    convert::Infallible,
     fmt::Display,
     io::{self, Write},
     num::NonZero,
@@ -265,6 +264,30 @@ impl<T: Display> ValueWithDesc<T> {
     }
 }
 
+macro_rules! impl_selectable {
+    ($type:ty) => {
+        impl Selectable for $type {
+            type Error = <$type as FromStr>::Err;
+            type Value = $type;
+
+            fn value(self) -> $type {
+                self
+            }
+
+            fn parse(input: &str) -> Result<$type, Self::Error> {
+                input.parse()
+            }
+        }
+    };
+    ($($type:ty),*) => {
+        $(
+            impl_selectable!($type);
+        )*
+    };
+}
+
+impl_selectable!(i32, f32, String);
+
 impl<T> From<T> for ValueWithDesc<T> {
     fn from(value: T) -> Self {
         ValueWithDesc::Value(value)
@@ -277,19 +300,6 @@ impl From<&str> for ValueWithDesc<String> {
     }
 }
 
-impl Selectable for ValueWithDesc<i32> {
-    type Error = <i32 as FromStr>::Err;
-    type Value = i32;
-
-    fn value(self) -> i32 {
-        self.value()
-    }
-
-    fn parse(input: &str) -> Result<i32, Self::Error> {
-        input.parse()
-    }
-}
-
 impl<T: Display> Display for ValueWithDesc<T> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
@@ -299,29 +309,16 @@ impl<T: Display> Display for ValueWithDesc<T> {
     }
 }
 
-impl Selectable for ValueWithDesc<f32> {
-    type Error = <f32 as FromStr>::Err;
-    type Value = f32;
+impl<T: Selectable + Display> Selectable for ValueWithDesc<T> {
+    type Error = T::Error;
+    type Value = T::Value;
 
-    fn value(self) -> f32 {
-        self.value()
+    fn value(self) -> T::Value {
+        self.value().value()
     }
 
-    fn parse(input: &str) -> Result<f32, Self::Error> {
-        input.parse()
-    }
-}
-
-impl Selectable for ValueWithDesc<String> {
-    type Error = Infallible;
-    type Value = String;
-
-    fn value(self) -> String {
-        self.value()
-    }
-
-    fn parse(input: &str) -> Result<String, Self::Error> {
-        Ok(input.to_owned())
+    fn parse(input: &str) -> Result<T::Value, Self::Error> {
+        T::parse(input)
     }
 }
 


### PR DESCRIPTION
## Summary by Sourcery

为原始类型引入基于宏实现的 `Selectable` trait，并基于任意实现了 `Selectable` 的值类型，为 `ValueWithDesc` 添加通用的 `Selectable` 实现。

Enhancements:
- 使用可复用的宏替换针对单个类型的 `Selectable` 实现，该宏为 `i32`、`f32` 和 `String` 实现 `Selectable`。
- 将 `ValueWithDesc` 泛化，使其能够为任意内部类型实现 `Selectable`，前提是该内部类型本身实现了 `Selectable` 和 `Display`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a macro-based implementation of the Selectable trait for primitive types and add a generic Selectable implementation for ValueWithDesc based on any Selectable value type.

Enhancements:
- Replace per-type Selectable implementations with a reusable macro that implements Selectable for i32, f32, and String.
- Generalize ValueWithDesc to implement Selectable for any inner type that itself implements Selectable and Display.

</details>