### PR TITLE
feat: impl selectable for TouchMode and ClientType

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1180,6 +1180,7 @@ dependencies = [
  "clap",
  "maa-ffi-string",
  "maa-ffi-types",
+ "maa-question",
  "schemars",
  "serde",
  "serde_test",

--- a/crates/maa-types/Cargo.toml
+++ b/crates/maa-types/Cargo.toml
@@ -10,6 +10,7 @@ license.workspace = true
 clap = { workspace = true, optional = true }
 maa-ffi-string = { workspace = true, optional = true }
 maa-ffi-types = { workspace = true }
+maa-question = { workspace = true, optional = true }
 schemars = { workspace = true, optional = true }
 serde = { workspace = true, optional = true }
 
@@ -20,6 +21,7 @@ serde_test = { workspace = true }
 clap = ["dep:clap"]
 ffi = ["dep:maa-ffi-string"]
 schema = ["dep:schemars", "serde"]
+selectable = ["dep:maa-question"]
 serde = ["dep:serde"]
 
 [lints]

--- a/crates/maa-types/src/client_type.rs
+++ b/crates/maa-types/src/client_type.rs
@@ -101,6 +101,9 @@ impl clap::ValueEnum for ClientType {
 
 impl_debug_display!(ClientType);
 
+#[cfg(feature = "selectable")]
+impl_selectable!(ClientType, UnknownClientTypeError);
+
 #[cfg(test)]
 #[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {

--- a/crates/maa-types/src/client_type.rs
+++ b/crates/maa-types/src/client_type.rs
@@ -237,4 +237,35 @@ mod tests {
         assert_eq!(YoStarJP.server_report(), Some("JP"));
         assert_eq!(YoStarKR.server_report(), Some("KR"));
     }
+
+    #[cfg(feature = "selectable")]
+    mod selectable {
+        use maa_question::question::Selectable;
+
+        use super::*;
+
+        #[test]
+        fn value() {
+            assert_eq!(Official.value(), Official);
+            assert_eq!(Bilibili.value(), Bilibili);
+            assert_eq!(Txwy.value(), Txwy);
+            assert_eq!(YoStarEN.value(), YoStarEN);
+            assert_eq!(YoStarJP.value(), YoStarJP);
+            assert_eq!(YoStarKR.value(), YoStarKR);
+        }
+
+        #[test]
+        fn parse() {
+            assert_eq!(ClientType::parse("Official").unwrap(), Official);
+            assert_eq!(ClientType::parse("Bilibili").unwrap(), Bilibili);
+            assert_eq!(ClientType::parse("txwy").unwrap(), Txwy);
+            assert_eq!(ClientType::parse("YoStarEN").unwrap(), YoStarEN);
+            assert_eq!(ClientType::parse("YoStarJP").unwrap(), YoStarJP);
+            assert_eq!(ClientType::parse("YoStarKR").unwrap(), YoStarKR);
+            assert_eq!(
+                ClientType::parse("Unknown").unwrap_err(),
+                UnknownClientTypeError("Unknown".to_owned())
+            );
+        }
+    }
 }

--- a/crates/maa-types/src/enum_macros.rs
+++ b/crates/maa-types/src/enum_macros.rs
@@ -237,3 +237,21 @@ macro_rules! impl_debug_display {
         }
     };
 }
+
+#[cfg(feature = "selectable")]
+macro_rules! impl_selectable {
+    ($enum_type:ty, $error_type:ty) => {
+        impl ::maa_question::question::Selectable for $enum_type {
+            type Error = $error_type;
+            type Value = $enum_type;
+
+            fn value(self) -> Self::Value {
+                self
+            }
+
+            fn parse(input: &str) -> Result<Self::Value, Self::Error> {
+                input.parse()
+            }
+        }
+    };
+}

--- a/crates/maa-types/src/touch_mode.rs
+++ b/crates/maa-types/src/touch_mode.rs
@@ -56,6 +56,9 @@ impl maa_ffi_string::ToCString for TouchMode {
 
 impl_debug_display!(TouchMode);
 
+#[cfg(feature = "selectable")]
+impl_selectable!(TouchMode, UnknownTouchModeError);
+
 #[cfg(test)]
 #[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {

--- a/crates/maa-types/src/touch_mode.rs
+++ b/crates/maa-types/src/touch_mode.rs
@@ -167,4 +167,39 @@ mod tests {
         assert_eq!(format!("{}", TouchMode::Adb), "adb");
         assert_eq!(format!("{:?}", TouchMode::MiniTouch), "minitouch");
     }
+
+    #[cfg(feature = "selectable")]
+    mod selectable {
+        use maa_question::question::Selectable;
+
+        use super::*;
+
+        #[test]
+        fn value() {
+            assert_eq!(TouchMode::Adb.value(), TouchMode::Adb);
+            assert_eq!(TouchMode::MiniTouch.value(), TouchMode::MiniTouch);
+            assert_eq!(TouchMode::MaaTouch.value(), TouchMode::MaaTouch);
+            assert_eq!(TouchMode::MacPlayTools.value(), TouchMode::MacPlayTools);
+            assert_eq!(TouchMode::MaaFwAdb.value(), TouchMode::MaaFwAdb);
+        }
+
+        #[test]
+        fn parse() {
+            assert_eq!(TouchMode::parse("adb").unwrap(), TouchMode::Adb);
+            assert_eq!(TouchMode::parse("minitouch").unwrap(), TouchMode::MiniTouch);
+            assert_eq!(TouchMode::parse("maatouch").unwrap(), TouchMode::MaaTouch);
+            assert_eq!(
+                TouchMode::parse("MacPlayTools").unwrap(),
+                TouchMode::MacPlayTools
+            );
+            assert_eq!(
+                TouchMode::parse("MaaFwAdb").unwrap(),
+                TouchMode::MaaFwAdb
+            );
+            assert_eq!(
+                TouchMode::parse("Unknown").unwrap_err(),
+                UnknownTouchModeError("Unknown".to_owned())
+            );
+        }
+    }
 }

--- a/crates/maa-types/src/touch_mode.rs
+++ b/crates/maa-types/src/touch_mode.rs
@@ -192,10 +192,7 @@ mod tests {
                 TouchMode::parse("MacPlayTools").unwrap(),
                 TouchMode::MacPlayTools
             );
-            assert_eq!(
-                TouchMode::parse("MaaFwAdb").unwrap(),
-                TouchMode::MaaFwAdb
-            );
+            assert_eq!(TouchMode::parse("MaaFwAdb").unwrap(), TouchMode::MaaFwAdb);
             assert_eq!(
                 TouchMode::parse("Unknown").unwrap_err(),
                 UnknownTouchModeError("Unknown".to_owned())


### PR DESCRIPTION
## 由 Sourcery 提供的总结

在一个新的功能开关（feature flag）后面，为触控模式（TouchMode）和客户端类型（ClientType）枚举添加可选的 `Selectable` 支持。

新功能：
- 引入一个可复用的宏，当启用 `selectable` 功能时，为枚举实现 `Selectable` trait。
- 使用新的宏为 `ClientType` 和 `TouchMode` 启用 `Selectable` trait 支持，并通过 `selectable` 功能开关进行控制。

构建：
- 声明可选依赖 `maa-question`，并将其连接到 `maa-types` 中新的 `selectable` Cargo 功能。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add optional Selectable support for touch mode and client type enums behind a new feature flag.

New Features:
- Introduce a reusable macro to implement the Selectable trait for enums when the selectable feature is enabled.
- Enable Selectable trait support for ClientType and TouchMode using the new macro, gated behind the selectable feature flag.

Build:
- Declare the maa-question optional dependency and wire it to the new selectable Cargo feature in maa-types.

</details>