### PR TITLE
feat(config): support GitHub proxy for release downloads via ureq middleware

### DIFF
--- a/crates/maa-cli/config_examples/cli.toml
+++ b/crates/maa-cli/config_examples/cli.toml
@@ -1,5 +1,11 @@
 "$schema" = "../schemas/cli.schema.json"
 
+# GitHub proxy prefix for accelerating downloads
+# When set, all GitHub releases download URLs (github.com/*/releases/download/*)
+# will be transparently rewritten through this proxy via ureq middleware.
+# This affects maa-core, maa-cli self-update, and hot-update downloads.
+# github_proxy = "https://gh-proxy.org/"
+
 # Configurations for MaaCore installation and update
 [core]
 # Update channel of MaaCore, can be "Alpha", "Beta" or "Stable"

--- a/crates/maa-cli/src/config/cli/mod.rs
+++ b/crates/maa-cli/src/config/cli/mod.rs
@@ -20,6 +20,11 @@ use crate::dirs;
 #[cfg_attr(test, derive(Debug, PartialEq))]
 #[derive(Deserialize, Default)]
 pub struct CLIConfig {
+    /// GitHub proxy prefix for accelerating downloads.
+    ///
+    /// When set, GitHub release download URLs (`github.com/*/releases/download/*`)
+    /// will be transparently rewritten through this proxy via ureq middleware.
+    github_proxy: Option<String>,
     /// MaaCore configuration
     #[cfg(feature = "core_installer")]
     #[serde(default)]
@@ -34,6 +39,17 @@ pub struct CLIConfig {
 }
 
 impl CLIConfig {
+    /// Get the GitHub proxy prefix.
+    ///
+    /// Returns the configured value, if non-empty.
+    /// Trailing slashes are stripped.
+    pub fn github_proxy(&self) -> Option<String> {
+        self.github_proxy
+            .as_deref()
+            .filter(|s| !s.is_empty())
+            .map(|s| s.trim_end_matches('/').to_string())
+    }
+
     #[cfg(feature = "core_installer")]
     pub fn core_config(&self) -> maa_core::Config {
         self.core.clone()
@@ -231,6 +247,7 @@ mod tests {
                 .unwrap();
 
         let expect = CLIConfig {
+            github_proxy: None,
             #[cfg(feature = "core_installer")]
             core: maa_core::tests::example_config(),
             #[cfg(feature = "cli_installer")]
@@ -314,5 +331,49 @@ mod tests {
     fn normalize_url_test() {
         assert_eq!(normalize_url("https://foo.bar"), "https://foo.bar");
         assert_eq!(normalize_url("https://foo.bar/"), "https://foo.bar");
+    }
+
+    mod github_proxy {
+        use super::*;
+
+        #[test]
+        fn config_value() {
+            // Config with trailing slash → stripped
+            let config = CLIConfig {
+                github_proxy: Some("https://config.example/".to_string()),
+                ..Default::default()
+            };
+            assert_eq!(
+                config.github_proxy(),
+                Some("https://config.example".to_string())
+            );
+        }
+
+        #[test]
+        fn config_without_trailing_slash() {
+            let config = CLIConfig {
+                github_proxy: Some("https://config.example".to_string()),
+                ..Default::default()
+            };
+            assert_eq!(
+                config.github_proxy(),
+                Some("https://config.example".to_string())
+            );
+        }
+
+        #[test]
+        fn empty_config_is_none() {
+            let config = CLIConfig {
+                github_proxy: Some("".to_string()),
+                ..Default::default()
+            };
+            assert_eq!(config.github_proxy(), None);
+        }
+
+        #[test]
+        fn none_config_is_none() {
+            let config = CLIConfig::default();
+            assert_eq!(config.github_proxy(), None);
+        }
     }
 }

--- a/crates/maa-cli/src/installer/maa_core.rs
+++ b/crates/maa-cli/src/installer/maa_core.rs
@@ -30,11 +30,12 @@ struct CoreAsset<'a>(&'a core::Asset);
 impl CoreManifest {
     fn from_reader(file: std::fs::File) -> maa_installer::error::Result<Self> {
         use maa_installer::error::{Error, ErrorKind};
-        let manifest = serde_json::from_reader(file).map_err(|e| {
-            Error::new(ErrorKind::Other)
-                .with_source(e)
-                .with_desc("Failed to parse core version manifest")
-        })?;
+        let manifest: VersionManifest<core::Details> =
+            serde_json::from_reader(file).map_err(|e| {
+                Error::new(ErrorKind::Other)
+                    .with_source(e)
+                    .with_desc("Failed to parse core version manifest")
+            })?;
 
         Ok(CoreManifest(manifest))
     }

--- a/crates/maa-cli/src/state.rs
+++ b/crates/maa-cli/src/state.rs
@@ -4,9 +4,12 @@ use std::sync::LazyLock;
 
 use semver::Version;
 use ureq::{
-    Agent,
+    Agent, Body, SendBody,
+    middleware::{Middleware, MiddlewareNext},
     tls::{RootCerts, TlsConfig},
 };
+
+use crate::config::cli::CLI_CONFIG;
 
 pub const CLI_VERSION_STR: &str = env!("MAA_VERSION");
 
@@ -23,14 +26,105 @@ pub static CORE_VERSION: LazyLock<Option<Version>> = LazyLock::new(|| {
     })
 });
 
+/// Rewrite a GitHub release download URL through a proxy.
+///
+/// Returns `Some(new_url)` if the URL is a GitHub release download
+/// (`github.com/*/releases/download/*`), `None` otherwise.
+/// Empty proxy is treated as no-op, returning `None`.
+pub(crate) fn rewrite_github_url(url: &str, proxy: &str) -> Option<String> {
+    let proxy = proxy.trim();
+    if proxy.is_empty() {
+        return None;
+    }
+    // Must be a github.com URL with /releases/download/ in the path
+    if !url.contains("github.com/") || !url.contains("/releases/download/") {
+        return None;
+    }
+    // Ensure it's the host, not just somewhere in the URL
+    let rest = url.strip_prefix("https://github.com/")?;
+    if !rest.contains("/releases/download/") {
+        return None;
+    }
+    let proxy = proxy.trim_end_matches('/');
+    Some(format!("{proxy}/{url}"))
+}
+
+/// Middleware that rewrites GitHub release download URLs through a proxy.
+struct GitHubProxyMiddleware {
+    proxy: String,
+}
+
+impl Middleware for GitHubProxyMiddleware {
+    fn handle(
+        &self,
+        mut req: ureq::http::Request<SendBody>,
+        next: MiddlewareNext,
+    ) -> Result<ureq::http::Response<Body>, ureq::Error> {
+        let uri_str = req.uri().to_string();
+        if let Some(new_url) = rewrite_github_url(&uri_str, &self.proxy)
+            && let Ok(uri) = new_url.parse()
+        {
+            *req.uri_mut() = uri;
+        }
+        next.handle(req)
+    }
+}
+
 pub static AGENT: LazyLock<Agent> = LazyLock::new(|| {
-    Agent::config_builder()
+    let mut config = Agent::config_builder()
         .tls_config(
             TlsConfig::builder()
                 .root_certs(RootCerts::PlatformVerifier)
                 .build(),
         )
-        .user_agent(format!("maa-cli/{CLI_VERSION_STR}"))
-        .build()
-        .into()
+        .user_agent(format!("maa-cli/{CLI_VERSION_STR}"));
+
+    if let Some(proxy) = CLI_CONFIG.github_proxy() {
+        config = config.middleware(GitHubProxyMiddleware { proxy });
+    }
+
+    config.build().into()
 });
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rewrite_github_release_url() {
+        let url = "https://github.com/MaaAssistantArknights/MaaAssistantArknights/releases/download/v4.26.1/MAA-v4.26.1-linux-x86_64.tar.gz";
+        let result = rewrite_github_url(url, "https://hk.gh-proxy.org");
+        assert_eq!(
+            result,
+            Some("https://hk.gh-proxy.org/https://github.com/MaaAssistantArknights/MaaAssistantArknights/releases/download/v4.26.1/MAA-v4.26.1-linux-x86_64.tar.gz".to_string())
+        );
+    }
+
+    #[test]
+    fn rewrite_with_trailing_slash_proxy() {
+        let url = "https://github.com/MaaAssistantArknights/MaaAssistantArknights/releases/download/v4.26.1/MAA-v4.26.1-linux-x86_64.tar.gz";
+        let result = rewrite_github_url(url, "https://hk.gh-proxy.org/");
+        assert_eq!(
+            result,
+            Some("https://hk.gh-proxy.org/https://github.com/MaaAssistantArknights/MaaAssistantArknights/releases/download/v4.26.1/MAA-v4.26.1-linux-x86_64.tar.gz".to_string())
+        );
+    }
+
+    #[test]
+    fn non_github_url_unchanged() {
+        let url = "https://example.com/file.tar.gz";
+        assert_eq!(rewrite_github_url(url, "https://hk.gh-proxy.org"), None);
+    }
+
+    #[test]
+    fn github_raw_url_unchanged() {
+        let url = "https://github.com/MaaAssistantArknights/MaaRelease/raw/main/version.json";
+        assert_eq!(rewrite_github_url(url, "https://hk.gh-proxy.org"), None);
+    }
+
+    #[test]
+    fn empty_proxy_is_noop() {
+        let url = "https://github.com/MaaAssistantArknights/MaaAssistantArknights/releases/download/v4.26.1/MAA-v4.26.1-linux-x86_64.tar.gz";
+        assert_eq!(rewrite_github_url(url, ""), None);
+    }
+}

--- a/crates/maa-cli/src/state.rs
+++ b/crates/maa-cli/src/state.rs
@@ -63,6 +63,11 @@ static GITHUB_PROXY: LazyLock<Option<String>> = LazyLock::new(|| {
         .and_then(|cfg| cfg.github_proxy())
 });
 
+/// Apply the proxy prefix to a URI if it is a GitHub release download URL.
+fn rewrite_uri(uri: &ureq::http::Uri, proxy: &str) -> Option<ureq::http::Uri> {
+    rewrite_github_url(&uri.to_string(), proxy).and_then(|new_url| new_url.parse().ok())
+}
+
 /// Middleware that rewrites GitHub release download URLs through a proxy.
 struct GitHubProxyMiddleware;
 
@@ -72,13 +77,10 @@ impl Middleware for GitHubProxyMiddleware {
         mut req: ureq::http::Request<SendBody>,
         next: MiddlewareNext,
     ) -> Result<ureq::http::Response<Body>, ureq::Error> {
-        if let Some(proxy) = GITHUB_PROXY.as_deref() {
-            let uri_str = req.uri().to_string();
-            if let Some(new_url) = rewrite_github_url(&uri_str, proxy)
-                && let Ok(uri) = new_url.parse()
-            {
-                *req.uri_mut() = uri;
-            }
+        if let Some(proxy) = GITHUB_PROXY.as_deref()
+            && let Some(uri) = rewrite_uri(req.uri(), proxy)
+        {
+            *req.uri_mut() = uri;
         }
         next.handle(req)
     }
@@ -140,5 +142,74 @@ mod tests {
     fn empty_proxy_is_noop() {
         let url = "https://github.com/MaaAssistantArknights/MaaAssistantArknights/releases/download/v4.26.1/MAA-v4.26.1-linux-x86_64.tar.gz";
         assert_eq!(rewrite_github_url(url, ""), None);
+    }
+
+    #[test]
+    fn rewrite_uri_github_release() {
+        let uri: ureq::http::Uri = "https://github.com/MaaAssistantArknights/MaaAssistantArknights/releases/download/v4.26.1/MAA-v4.26.1-linux-x86_64.tar.gz"
+            .parse()
+            .unwrap();
+        let result = rewrite_uri(&uri, "https://hk.gh-proxy.org");
+        assert_eq!(
+            result.map(|u| u.to_string()),
+            Some("https://hk.gh-proxy.org/https://github.com/MaaAssistantArknights/MaaAssistantArknights/releases/download/v4.26.1/MAA-v4.26.1-linux-x86_64.tar.gz".to_string())
+        );
+    }
+
+    #[test]
+    fn rewrite_uri_non_github() {
+        let uri: ureq::http::Uri = "https://example.com/file.tar.gz".parse().unwrap();
+        assert_eq!(rewrite_uri(&uri, "https://hk.gh-proxy.org"), None);
+    }
+
+    #[test]
+    fn rewrite_uri_invalid_proxy_returns_none() {
+        // Proxy that would produce an invalid URL (e.g. empty) yields no rewrite.
+        let uri: ureq::http::Uri = "https://github.com/MaaAssistantArknights/MaaAssistantArknights/releases/download/v4.26.1/MAA-v4.26.1-linux-x86_64.tar.gz"
+            .parse()
+            .unwrap();
+        assert_eq!(rewrite_uri(&uri, ""), None);
+    }
+
+    #[test]
+    fn github_proxy_subprocess_parent() {
+        // Run a child process with an isolated MAA_CONFIG_DIR so that the
+        // process-wide GITHUB_PROXY/AGENT statics pick up a configured proxy.
+        // Environment variables set here never leak into other tests.
+        let exe = std::env::current_exe().unwrap();
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(
+            tmp.path().join("cli.toml"),
+            "github_proxy = \"https://hk.gh-proxy.org/\"\n",
+        )
+        .unwrap();
+        let output = std::process::Command::new(exe)
+            .env("MAA_GITHUB_PROXY_TEST", "1")
+            .env("MAA_CONFIG_DIR", tmp.path())
+            .args([
+                "--exact",
+                "state::tests::github_proxy_subprocess_child",
+                "--nocapture",
+            ])
+            .output()
+            .unwrap();
+        assert!(
+            output.status.success(),
+            "subprocess failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    #[test]
+    fn github_proxy_subprocess_child() {
+        // Only meaningful in the subprocess launched by the parent test;
+        // in a normal test run this is a no-op.
+        if std::env::var_os("MAA_GITHUB_PROXY_TEST").is_none() {
+            return;
+        }
+        // GITHUB_PROXY resolves from the isolated config dir, and AGENT
+        // installs the middleware when a proxy is configured.
+        assert_eq!(GITHUB_PROXY.as_deref(), Some("https://hk.gh-proxy.org"));
+        let _ = &*AGENT;
     }
 }

--- a/crates/maa-cli/src/state.rs
+++ b/crates/maa-cli/src/state.rs
@@ -9,7 +9,10 @@ use ureq::{
     tls::{RootCerts, TlsConfig},
 };
 
-use crate::config::cli::CLI_CONFIG;
+use crate::{
+    config::{FindFile, cli::CLIConfig},
+    dirs,
+};
 
 pub const CLI_VERSION_STR: &str = env!("MAA_VERSION");
 
@@ -49,10 +52,19 @@ pub(crate) fn rewrite_github_url(url: &str, proxy: &str) -> Option<String> {
     Some(format!("{proxy}/{url}"))
 }
 
+/// GitHub proxy prefix, read lazily from the config file.
+///
+/// Unlike `CLI_CONFIG`, this never panics: if the config file fails to parse
+/// (e.g. with a feature-gated field), the proxy is simply disabled.
+static GITHUB_PROXY: LazyLock<Option<String>> = LazyLock::new(|| {
+    CLIConfig::find_file_or_none(dirs::config().join("cli"))
+        .ok()
+        .flatten()
+        .and_then(|cfg| cfg.github_proxy())
+});
+
 /// Middleware that rewrites GitHub release download URLs through a proxy.
-struct GitHubProxyMiddleware {
-    proxy: String,
-}
+struct GitHubProxyMiddleware;
 
 impl Middleware for GitHubProxyMiddleware {
     fn handle(
@@ -60,11 +72,13 @@ impl Middleware for GitHubProxyMiddleware {
         mut req: ureq::http::Request<SendBody>,
         next: MiddlewareNext,
     ) -> Result<ureq::http::Response<Body>, ureq::Error> {
-        let uri_str = req.uri().to_string();
-        if let Some(new_url) = rewrite_github_url(&uri_str, &self.proxy)
-            && let Ok(uri) = new_url.parse()
-        {
-            *req.uri_mut() = uri;
+        if let Some(proxy) = GITHUB_PROXY.as_deref() {
+            let uri_str = req.uri().to_string();
+            if let Some(new_url) = rewrite_github_url(&uri_str, proxy)
+                && let Ok(uri) = new_url.parse()
+            {
+                *req.uri_mut() = uri;
+            }
         }
         next.handle(req)
     }
@@ -79,8 +93,8 @@ pub static AGENT: LazyLock<Agent> = LazyLock::new(|| {
         )
         .user_agent(format!("maa-cli/{CLI_VERSION_STR}"));
 
-    if let Some(proxy) = CLI_CONFIG.github_proxy() {
-        config = config.middleware(GitHubProxyMiddleware { proxy });
+    if GITHUB_PROXY.is_some() {
+        config = config.middleware(GitHubProxyMiddleware);
     }
 
     config.build().into()


### PR DESCRIPTION
## 功能说明

支持通过配置文件 `cli.toml` 中的 `github_proxy` 字段设置 GitHub 代理前缀，所有通过 ureq 的 GitHub release 下载将被透明改写走代理。

## 使用方式

```toml
# cli.toml
github_proxy = "https://gh-proxy.org/"
```

## 实现方式

采用 ureq middleware 方案（感谢 @wangl-cc 的建议），在全局 `AGENT` 构造时注入 `GitHubProxyMiddleware`，对 host 为 `github.com` 且路径含 `/releases/download/` 的请求透明改写 URL。覆盖所有通过 AGENT 的下载：maa-core、CLI 自更新、hot-update。

## 修改文件

- `crates/maa-cli/src/state.rs`：新增 `rewrite_github_url()` + `GitHubProxyMiddleware`，AGENT 构造时条件注入
- `crates/maa-cli/src/config/cli/mod.rs`：新增 `github_proxy` 配置字段及 `github_proxy()` 方法
- `crates/maa-cli/config_examples/cli.toml`：新增 `github_proxy` 配置示例及注释