### PR TITLE
fix(fish): unexpected output during completion in fish

### DIFF
--- a/crates/maa-cli/completions/maa.fish
+++ b/crates/maa-cli/completions/maa.fish
@@ -77,7 +77,7 @@ complete -c maa -n "__fish_seen_subcommand_from $run_commands" -l dry-run -d 'Pa
 complete -c maa -n "__fish_seen_subcommand_from $run_commands" -l no-summary -d 'Do not print summary when finnish'
 complete -c maa -n "__fish_seen_subcommand_from $run_commands" -f # prevent fish complete from path
 ## command specific options
-complete -c maa -n "__fish_seen_subcommand_from run" -f -a "$(maa list)"
+complete -c maa -n "__fish_seen_subcommand_from run" -f -a "$(maa list 2>/dev/null)"
 complete -c maa -n "__fish_seen_subcommand_from startup" -f -a "$clients"
 complete -c maa -n "__fish_seen_subcommand_from startup" -f -l account -d 'Account to login' -r
 complete -c maa -n "__fish_seen_subcommand_from closedown" -f -a "$clients"


### PR DESCRIPTION
修复在 fish 中补全时出现的额外输出。

修复前：


https://github.com/user-attachments/assets/224b7186-f8ac-4d7c-b606-5a03407f2917

## Summary by Sourcery

Bug Fixes:
- 通过在用于 `run` 子命令补全时将 `maa list` 的标准错误输出重定向到 `/dev/null`，防止其额外的错误输出在 Fish shell 补全过程中出现。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Prevent extra error output from `maa list` appearing during Fish shell completion by redirecting its stderr to `/dev/null` when used for `run` subcommand completions.

</details>