### PR TITLE
ci: use winget-create for WinGet PRs

### DIFF
--- a/.github/workflows/publish-winget.yml
+++ b/.github/workflows/publish-winget.yml
@@ -36,14 +36,56 @@ permissions:
 jobs:
   publish:
     name: Publish to Winget
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
+    env:
+      RELEASE_REPOSITORY: ${{ github.repository }}
+      RELEASE_TAG: ${{ inputs.tag || format('v{0}', inputs.version) }}
+      WINGET_CREATE_GITHUB_TOKEN: ${{ secrets.MAABOT_WINGET_TOKEN }}
+      WINGET_CREATE_VERSION: "v1.12.8.0"
+      WINGET_CREATE_SHA256: "8BD738851B524885410112678E3771B341C5C716DE60FBBECB88AB0A363ED85D"
     steps:
       - name: Update Winget Package
-        uses: vedantmgoyal9/winget-releaser@main
-        with:
-          identifier: MaaAssistantArknights.maa-cli
-          version: ${{ inputs.version }}
-          installers-regex: winget
-          release-tag: ${{ inputs.tag || format('v{0}', inputs.version) }}
-          fork-user: MaaAssistantArknights
-          token: ${{ secrets.MAABOT_WINGET_TOKEN }}
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+
+          if (-not $env:WINGET_CREATE_GITHUB_TOKEN) {
+            Write-Error "MAABOT_WINGET_TOKEN is required to submit the WinGet PR."
+            exit 1
+          }
+
+          $headers = @{
+            Accept                 = "application/vnd.github+json"
+            Authorization          = "Bearer $env:WINGET_CREATE_GITHUB_TOKEN"
+            "X-GitHub-Api-Version" = "2026-03-10"
+          }
+
+          $release = Invoke-RestMethod `
+            -Uri "https://api.github.com/repos/$env:RELEASE_REPOSITORY/releases/tags/$env:RELEASE_TAG" `
+            -Headers $headers
+
+          $escapedReleaseTag = [regex]::Escape($env:RELEASE_TAG)
+          $urlX64 = $release.assets |
+            Where-Object { $_.name -match "^maa_cli-$escapedReleaseTag-x86_64-pc-windows-msvc-winget\.zip$" } |
+            Select-Object -First 1 -ExpandProperty browser_download_url
+          $urlArm64 = $release.assets |
+            Where-Object { $_.name -match "^maa_cli-$escapedReleaseTag-aarch64-pc-windows-msvc-winget\.zip$" } |
+            Select-Object -First 1 -ExpandProperty browser_download_url
+
+          if (-not $urlX64 -or -not $urlArm64) {
+            $assetNames = ($release.assets | ForEach-Object { $_.name }) -join ', '
+            Write-Error "Failed to resolve WinGet release assets for tag '$env:RELEASE_TAG'. Assets: $assetNames"
+            exit 1
+          }
+
+          curl.exe -JLO "https://github.com/microsoft/winget-create/releases/download/$env:WINGET_CREATE_VERSION/wingetcreate.exe"
+
+          if ((Get-FileHash wingetcreate.exe).Hash -ne $env:WINGET_CREATE_SHA256) {
+            Write-Error "wingetcreate.exe hash does not match expected value. Aborting."
+            exit 1
+          }
+
+          .\wingetcreate.exe update MaaAssistantArknights.maa-cli `
+            --version "${{ inputs.version }}" `
+            --urls "$urlX64|x64" "$urlArm64|arm64" `
+            --submit


### PR DESCRIPTION
## Summary

- Replace `winget-releaser` with pinned `wingetcreate.exe` in the WinGet publish workflow.
- Resolve x64 and arm64 WinGet release asset URLs through the GitHub Releases API.
- Remove the `fork-user: MaaAssistantArknights`; PR submission now follows the `MAABOT_WINGET_TOKEN` account, so the MaaArknightsBot token will be `MaaArknightsBot/winget-pkgs`.

## Why

The previous workflow still pointed `winget-releaser` at the old `MaaAssistantArknights/winget-pkgs` fork. MaaAssistantArknights/MaaAssistantArknights#16813 also moved away from `winget-releaser` because it was producing incorrect manifests for nested installer packages.

## Validation

- `cargo +nightly fmt`
- YAML parse check with Ruby
- `actionlint .github/workflows/publish-winget.yml`
- `cargo clippy`
- `cargo x test`

Note: local `pwsh` is not installed, so PowerShell parsing was not run locally; the workflow now runs on `windows-latest`, where PowerShell is available.

## Summary by Sourcery

CI:
- 将 winget-releaser GitHub Action 替换为基于 PowerShell 的步骤：该步骤会下载并验证特定版本的 `wingetcreate.exe`，通过 GitHub Releases API 解析发布资产的 URL，并使用 `MAABOT_WINGET_TOKEN` 提交 WinGet 软件包更新。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

CI:
- Replace the winget-releaser GitHub Action with a PowerShell-based step that downloads and verifies a specific wingetcreate.exe version, resolves release asset URLs via the GitHub Releases API, and submits the WinGet package update using MAABOT_WINGET_TOKEN.

</details>

CI：
- 在 `windows-latest` 上运行 WinGet 发布工作流，而不是在 `ubuntu-latest` 上运行。
- 用内联 PowerShell 脚本替换 `winget-releaser` GitHub Action，该脚本会下载指定版本的 `wingetcreate.exe`，验证其哈希值，解析 x64/arm64 资源的 URL，并使用 `MAABOT_WINGET_TOKEN` 账号提交 WinGet PR。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

CI:
- 将 winget-releaser GitHub Action 替换为基于 PowerShell 的步骤：该步骤会下载并验证特定版本的 `wingetcreate.exe`，通过 GitHub Releases API 解析发布资产的 URL，并使用 `MAABOT_WINGET_TOKEN` 提交 WinGet 软件包更新。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

CI:
- Replace the winget-releaser GitHub Action with a PowerShell-based step that downloads and verifies a specific wingetcreate.exe version, resolves release asset URLs via the GitHub Releases API, and submits the WinGet package update using MAABOT_WINGET_TOKEN.

</details>

</details>