### PR TITLE
fix: Guard MaaCore runtime lifecycle state

### DIFF
--- a/crates/maa-core/src/error.rs
+++ b/crates/maa-core/src/error.rs
@@ -10,6 +10,15 @@ pub enum Error {
     BufferTooSmall,
     #[error("The content returned by MaaCore is too large (length > {0})")]
     ContentTooLarge(usize),
+    #[cfg(feature = "runtime")]
+    #[error("Cannot load or unload MaaCore runtime while Assistant instances are alive")]
+    ActiveAssistants,
+    #[cfg(feature = "runtime")]
+    #[error("Cannot create Assistant while MaaCore runtime is loading or unloading")]
+    RuntimeChanging,
+    #[cfg(feature = "runtime")]
+    #[error("Cannot create Assistant before MaaCore runtime is loaded")]
+    RuntimeNotLoaded,
     #[error("Input argument contains invalid bytes")]
     InvalidArgument(#[from] maa_ffi_string::Error),
     #[error("Returned value contains invalid bytes")]

--- a/crates/maa-core/src/error.rs
+++ b/crates/maa-core/src/error.rs
@@ -14,7 +14,7 @@ pub enum Error {
     #[error("Cannot load or unload MaaCore runtime while Assistant instances are alive")]
     ActiveAssistants,
     #[cfg(feature = "runtime")]
-    #[error("Cannot create Assistant while MaaCore runtime is loading or unloading")]
+    #[error("Cannot perform this operation while MaaCore runtime is loading or unloading")]
     RuntimeChanging,
     #[cfg(feature = "runtime")]
     #[error("Cannot create Assistant before MaaCore runtime is loaded")]

--- a/crates/maa-core/src/error.rs
+++ b/crates/maa-core/src/error.rs
@@ -19,6 +19,9 @@ pub enum Error {
     #[cfg(feature = "runtime")]
     #[error("Cannot create Assistant before MaaCore runtime is loaded")]
     RuntimeNotLoaded,
+    #[cfg(feature = "runtime")]
+    #[error("Cannot create Assistant because too many Assistant instances are alive")]
+    TooManyAssistants,
     #[error("Input argument contains invalid bytes")]
     InvalidArgument(#[from] maa_ffi_string::Error),
     #[error("Returned value contains invalid bytes")]

--- a/crates/maa-core/src/lib.rs
+++ b/crates/maa-core/src/lib.rs
@@ -17,6 +17,8 @@ mod error;
 use error::{AsstResult, BufferTooSmall};
 pub use error::{Error, Result};
 
+mod runtime_lifecycle;
+
 /// The user directory of the assistant.
 static USER_DIR: RwLock<std::path::PathBuf> = RwLock::new(std::path::PathBuf::new());
 
@@ -42,68 +44,11 @@ pub struct Assistant {
 impl Drop for Assistant {
     fn drop(&mut self) {
         // Destroy the handle before the callback is dropped to make sure the callback is not used
-        // after the Box is freed.
+        // after the Box is freed. The active-assistant count is decremented after this call so a
+        // concurrent runtime load or unload still sees this instance as alive during destruction.
         unsafe { maa_sys::binding::AsstDestroy(self.handle) };
-    }
-}
 
-#[cfg(feature = "runtime")]
-impl Assistant {
-    /// Load the shared library of the MaaCore
-    ///
-    /// Must be called first before any other method.
-    pub fn load(path: impl AsRef<std::path::Path>) -> Result<()> {
-        let path = path.as_ref();
-
-        #[cfg(target_os = "windows")]
-        if let Some(dir) = path.parent() {
-            use windows_strings::HSTRING;
-            use windows_sys::Win32::System::LibraryLoader::SetDllDirectoryW;
-
-            if dir != std::path::Path::new(".") {
-                // Safety: HSTRING::as_ptr returns a valid, NUL-terminated wide
-                // string pointer that lives for the duration of this call.
-                let code = unsafe { SetDllDirectoryW(HSTRING::from(dir).as_ptr()) };
-                if code == 0 {
-                    windows_result::HRESULT::from_thread().ok()?;
-                }
-            }
-        }
-
-        maa_sys::binding::load(path)?;
-
-        Ok(())
-    }
-
-    /// Unload the shared library of the MaaCore.
-    ///
-    /// Must be called after all assistant instances are destroyed.
-    pub fn unload() -> Result<()> {
-        maa_sys::binding::unload();
-        Ok(())
-    }
-
-    /// Check if the shared library of the MaaCore is loaded in this thread.
-    pub fn loaded() -> bool {
-        maa_sys::binding::loaded()
-    }
-}
-
-#[cfg(not(feature = "runtime"))]
-impl Assistant {
-    /// Do nothing, as MaaCore is dynamically linked
-    pub fn load(_: impl AsRef<std::path::Path>) -> Result<()> {
-        Ok(())
-    }
-
-    /// Do nothing, as MaaCore is dynamically linked
-    pub fn unload() -> Result<()> {
-        Ok(())
-    }
-
-    /// Always returns true, as MaaCore is dynamically linked.
-    pub fn loaded() -> bool {
-        true
+        runtime_lifecycle::unregister_assistant();
     }
 }
 
@@ -170,10 +115,15 @@ impl Assistant {
 impl Assistant {
     /// Create a new assistant instance without a callback.
     pub fn new() -> Result<Self> {
+        let registration = runtime_lifecycle::PendingAssistantRegistration::begin()?;
+
         let handle = unsafe { maa_sys::binding::AsstCreate() };
         if handle.is_null() {
             return Err(Error::NullHandle);
         }
+
+        registration.commit();
+
         Ok(Self {
             handle,
             _callback: None,
@@ -187,10 +137,16 @@ impl Assistant {
     pub fn new_with_callback<C: Callback + 'static>(callback: C) -> Result<Self> {
         let boxed = Box::new(callback);
         let raw = &raw const *boxed as *mut c_void;
+
+        let registration = runtime_lifecycle::PendingAssistantRegistration::begin()?;
+
         let handle = unsafe { maa_sys::binding::AsstCreateEx(Some(trampoline::<C>), raw) };
         if handle.is_null() {
             return Err(Error::NullHandle);
         }
+
+        registration.commit();
+
         Ok(Self {
             handle,
             _callback: Some(boxed as Box<dyn Callback>),

--- a/crates/maa-core/src/runtime_lifecycle/linked.rs
+++ b/crates/maa-core/src/runtime_lifecycle/linked.rs
@@ -1,0 +1,32 @@
+use std::path::Path;
+
+use crate::{Assistant, Result};
+
+impl Assistant {
+    /// Do nothing, as MaaCore is dynamically linked
+    pub fn load(_: impl AsRef<Path>) -> Result<()> {
+        Ok(())
+    }
+
+    /// Do nothing, as MaaCore is dynamically linked
+    pub fn unload() -> Result<()> {
+        Ok(())
+    }
+
+    /// Always returns true, as MaaCore is dynamically linked.
+    pub fn loaded() -> bool {
+        true
+    }
+}
+
+pub(crate) struct PendingAssistantRegistration;
+
+impl PendingAssistantRegistration {
+    pub(crate) fn begin() -> Result<Self> {
+        Ok(Self)
+    }
+
+    pub(crate) fn commit(self) {}
+}
+
+pub(crate) fn unregister_assistant() {}

--- a/crates/maa-core/src/runtime_lifecycle/mod.rs
+++ b/crates/maa-core/src/runtime_lifecycle/mod.rs
@@ -1,0 +1,9 @@
+#[cfg(not(feature = "runtime"))]
+mod linked;
+#[cfg(feature = "runtime")]
+mod runtime;
+
+#[cfg(not(feature = "runtime"))]
+pub(crate) use linked::*;
+#[cfg(feature = "runtime")]
+pub(crate) use runtime::*;

--- a/crates/maa-core/src/runtime_lifecycle/runtime.rs
+++ b/crates/maa-core/src/runtime_lifecycle/runtime.rs
@@ -1,0 +1,328 @@
+use std::{
+    path::Path,
+    sync::atomic::{AtomicUsize, Ordering},
+};
+
+use crate::{Assistant, Error, Result};
+
+const RUNTIME_LOCKED: usize = 1usize << (usize::BITS - 1);
+const RUNTIME_LOADED: usize = 1usize << (usize::BITS - 2);
+const ASSISTANT_COUNT_MASK: usize = RUNTIME_LOADED - 1;
+
+static RUNTIME_STATE: AtomicUsize = AtomicUsize::new(0);
+
+fn is_locked(state: usize) -> bool {
+    state & RUNTIME_LOCKED != 0
+}
+
+fn is_loaded(state: usize) -> bool {
+    state & RUNTIME_LOADED != 0
+}
+
+fn assistant_count(state: usize) -> usize {
+    state & ASSISTANT_COUNT_MASK
+}
+
+enum StableState {
+    Loaded,
+    Unloaded,
+}
+
+impl StableState {
+    fn raw(&self) -> usize {
+        match self {
+            Self::Loaded => RUNTIME_LOADED,
+            Self::Unloaded => 0,
+        }
+    }
+}
+
+struct RuntimeChange {
+    committed: bool,
+}
+
+impl RuntimeChange {
+    fn begin() -> Result<Self> {
+        loop {
+            let state = RUNTIME_STATE.load(Ordering::Acquire);
+            if is_locked(state) {
+                return Err(Error::RuntimeChanging);
+            }
+
+            if RUNTIME_STATE
+                .compare_exchange(
+                    state,
+                    state | RUNTIME_LOCKED,
+                    Ordering::AcqRel,
+                    Ordering::Acquire,
+                )
+                .is_err()
+            {
+                continue;
+            }
+
+            let locked_state = RUNTIME_STATE.load(Ordering::Acquire);
+            if assistant_count(locked_state) > 0 {
+                RUNTIME_STATE.fetch_and(!RUNTIME_LOCKED, Ordering::AcqRel);
+                return Err(Error::ActiveAssistants);
+            }
+
+            return Ok(Self { committed: false });
+        }
+    }
+
+    fn commit(mut self, state: StableState) {
+        RUNTIME_STATE.store(state.raw(), Ordering::Release);
+        self.committed = true;
+    }
+}
+
+impl Drop for RuntimeChange {
+    fn drop(&mut self) {
+        if !self.committed {
+            RUNTIME_STATE.fetch_and(!RUNTIME_LOCKED, Ordering::AcqRel);
+        }
+    }
+}
+
+impl Assistant {
+    /// Load the shared library of the MaaCore
+    ///
+    /// Must be called before any other method.
+    /// Fails if any assistant instances are alive.
+    pub fn load(path: impl AsRef<Path>) -> Result<()> {
+        let path = path.as_ref();
+        let runtime_change = RuntimeChange::begin()?;
+
+        #[cfg(target_os = "windows")]
+        if let Some(dir) = path.parent() {
+            use windows_strings::HSTRING;
+            use windows_sys::Win32::System::LibraryLoader::SetDllDirectoryW;
+
+            if dir != Path::new(".") {
+                // Safety: HSTRING::as_ptr returns a valid, NUL-terminated wide
+                // string pointer that lives for the duration of this call.
+                let code = unsafe { SetDllDirectoryW(HSTRING::from(dir).as_ptr()) };
+                if code == 0 {
+                    windows_result::HRESULT::from_thread().ok()?;
+                }
+            }
+        }
+
+        maa_sys::binding::load(path)?;
+        runtime_change.commit(StableState::Loaded);
+        Ok(())
+    }
+
+    /// Unload the shared library of the MaaCore.
+    ///
+    /// Must be called after all assistant instances are destroyed.
+    /// Fails if any assistant instances are alive.
+    pub fn unload() -> Result<()> {
+        let runtime_change = RuntimeChange::begin()?;
+        maa_sys::binding::unload();
+        runtime_change.commit(StableState::Unloaded);
+        Ok(())
+    }
+
+    /// Check if the shared library of the MaaCore is loaded in this thread.
+    pub fn loaded() -> bool {
+        maa_sys::binding::loaded()
+    }
+}
+
+pub(crate) struct PendingAssistantRegistration {
+    committed: bool,
+}
+
+impl PendingAssistantRegistration {
+    pub(crate) fn begin() -> Result<Self> {
+        loop {
+            let state = RUNTIME_STATE.load(Ordering::Acquire);
+            if is_locked(state) {
+                return Err(Error::RuntimeChanging);
+            }
+
+            if !is_loaded(state) {
+                return Err(Error::RuntimeNotLoaded);
+            }
+
+            let count = assistant_count(state);
+            let next_count = count
+                .checked_add(1)
+                .filter(|count| *count <= ASSISTANT_COUNT_MASK)
+                .expect("Assistant count overflowed");
+            let next = (state & !ASSISTANT_COUNT_MASK) | next_count;
+            if RUNTIME_STATE
+                .compare_exchange(state, next, Ordering::AcqRel, Ordering::Acquire)
+                .is_ok()
+            {
+                return Ok(Self { committed: false });
+            }
+        }
+    }
+
+    pub(crate) fn commit(mut self) {
+        self.committed = true;
+    }
+}
+
+impl Drop for PendingAssistantRegistration {
+    fn drop(&mut self) {
+        if !self.committed {
+            unregister_assistant();
+        }
+    }
+}
+
+pub(crate) fn unregister_assistant() {
+    let previous = RUNTIME_STATE.fetch_sub(1, Ordering::AcqRel);
+    debug_assert!(is_loaded(previous));
+    debug_assert!(assistant_count(previous) > 0);
+}
+
+#[cfg(test)]
+pub(crate) mod tests {
+    use super::*;
+
+    static RUNTIME_STATE_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    fn reset_runtime_state_for_test(state: usize) {
+        RUNTIME_STATE.store(state, Ordering::Release);
+    }
+
+    #[test]
+    fn runtime_change_rejects_active_assistants() {
+        let _state_lock = RUNTIME_STATE_TEST_LOCK.lock().unwrap();
+        reset_runtime_state_for_test(RUNTIME_LOADED);
+
+        let _registration = PendingAssistantRegistration::begin().unwrap();
+
+        assert!(matches!(
+            RuntimeChange::begin(),
+            Err(Error::ActiveAssistants)
+        ));
+    }
+
+    #[test]
+    fn assistant_registration_rejects_runtime_changes() {
+        let _state_lock = RUNTIME_STATE_TEST_LOCK.lock().unwrap();
+        reset_runtime_state_for_test(0);
+
+        let _runtime_change = RuntimeChange::begin().unwrap();
+
+        assert!(matches!(
+            PendingAssistantRegistration::begin(),
+            Err(Error::RuntimeChanging)
+        ));
+    }
+
+    #[test]
+    fn runtime_change_rejects_existing_runtime_change() {
+        let _state_lock = RUNTIME_STATE_TEST_LOCK.lock().unwrap();
+        reset_runtime_state_for_test(RUNTIME_LOCKED);
+
+        assert!(matches!(
+            RuntimeChange::begin(),
+            Err(Error::RuntimeChanging)
+        ));
+        assert_eq!(RUNTIME_STATE.load(Ordering::Acquire), RUNTIME_LOCKED);
+    }
+
+    #[test]
+    fn load_rejects_existing_runtime_change_before_ffi() {
+        let _state_lock = RUNTIME_STATE_TEST_LOCK.lock().unwrap();
+        reset_runtime_state_for_test(RUNTIME_LOCKED);
+
+        assert!(matches!(
+            Assistant::load("/this/library/does_not_exist.so"),
+            Err(Error::RuntimeChanging)
+        ));
+        assert_eq!(RUNTIME_STATE.load(Ordering::Acquire), RUNTIME_LOCKED);
+    }
+
+    #[test]
+    fn assistant_registration_rejects_unloaded_runtime() {
+        let _state_lock = RUNTIME_STATE_TEST_LOCK.lock().unwrap();
+        reset_runtime_state_for_test(0);
+
+        assert!(matches!(
+            PendingAssistantRegistration::begin(),
+            Err(Error::RuntimeNotLoaded)
+        ));
+    }
+
+    #[test]
+    fn runtime_change_restores_state_without_commit() {
+        let _state_lock = RUNTIME_STATE_TEST_LOCK.lock().unwrap();
+        reset_runtime_state_for_test(RUNTIME_LOADED);
+
+        drop(RuntimeChange::begin().unwrap());
+
+        assert_eq!(RUNTIME_STATE.load(Ordering::Acquire), RUNTIME_LOADED);
+    }
+
+    #[test]
+    fn runtime_change_commits_state() {
+        let _state_lock = RUNTIME_STATE_TEST_LOCK.lock().unwrap();
+        reset_runtime_state_for_test(RUNTIME_LOADED);
+
+        RuntimeChange::begin()
+            .unwrap()
+            .commit(StableState::Unloaded);
+
+        assert_eq!(RUNTIME_STATE.load(Ordering::Acquire), 0);
+    }
+
+    #[test]
+    fn runtime_change_commits_loaded_state() {
+        let _state_lock = RUNTIME_STATE_TEST_LOCK.lock().unwrap();
+        reset_runtime_state_for_test(0);
+
+        RuntimeChange::begin().unwrap().commit(StableState::Loaded);
+
+        assert_eq!(RUNTIME_STATE.load(Ordering::Acquire), RUNTIME_LOADED);
+    }
+
+    #[test]
+    fn runtime_lock_preserves_assistant_count_changes() {
+        let _state_lock = RUNTIME_STATE_TEST_LOCK.lock().unwrap();
+        reset_runtime_state_for_test(RUNTIME_LOCKED | RUNTIME_LOADED | 1);
+
+        unregister_assistant();
+        RUNTIME_STATE.fetch_and(!RUNTIME_LOCKED, Ordering::AcqRel);
+
+        assert_eq!(RUNTIME_STATE.load(Ordering::Acquire), RUNTIME_LOADED);
+    }
+
+    #[test]
+    fn assistant_registration_rolls_back_without_commit() {
+        let _state_lock = RUNTIME_STATE_TEST_LOCK.lock().unwrap();
+        reset_runtime_state_for_test(RUNTIME_LOADED);
+
+        drop(PendingAssistantRegistration::begin().unwrap());
+
+        assert_eq!(RUNTIME_STATE.load(Ordering::Acquire), RUNTIME_LOADED);
+    }
+
+    #[test]
+    fn assistant_registration_commit_keeps_count() {
+        let _state_lock = RUNTIME_STATE_TEST_LOCK.lock().unwrap();
+        reset_runtime_state_for_test(RUNTIME_LOADED);
+
+        PendingAssistantRegistration::begin().unwrap().commit();
+
+        assert_eq!(RUNTIME_STATE.load(Ordering::Acquire), RUNTIME_LOADED | 1);
+        unregister_assistant();
+    }
+
+    #[test]
+    fn load_restores_state_after_failure() {
+        let _state_lock = RUNTIME_STATE_TEST_LOCK.lock().unwrap();
+        reset_runtime_state_for_test(RUNTIME_LOADED);
+
+        assert!(Assistant::load("/this/library/does_not_exist.so").is_err());
+
+        assert_eq!(RUNTIME_STATE.load(Ordering::Acquire), RUNTIME_LOADED);
+    }
+}

--- a/crates/maa-core/src/runtime_lifecycle/runtime.rs
+++ b/crates/maa-core/src/runtime_lifecycle/runtime.rs
@@ -151,7 +151,7 @@ impl PendingAssistantRegistration {
             let next_count = count
                 .checked_add(1)
                 .filter(|count| *count <= ASSISTANT_COUNT_MASK)
-                .expect("Assistant count overflowed");
+                .ok_or(Error::TooManyAssistants)?;
             let next = (state & !ASSISTANT_COUNT_MASK) | next_count;
             if RUNTIME_STATE
                 .compare_exchange(state, next, Ordering::AcqRel, Ordering::Acquire)
@@ -250,6 +250,21 @@ pub(crate) mod tests {
             PendingAssistantRegistration::begin(),
             Err(Error::RuntimeNotLoaded)
         ));
+    }
+
+    #[test]
+    fn assistant_registration_rejects_count_overflow() {
+        let _state_lock = RUNTIME_STATE_TEST_LOCK.lock().unwrap();
+        reset_runtime_state_for_test(RUNTIME_LOADED | ASSISTANT_COUNT_MASK);
+
+        assert!(matches!(
+            PendingAssistantRegistration::begin(),
+            Err(Error::TooManyAssistants)
+        ));
+        assert_eq!(
+            RUNTIME_STATE.load(Ordering::Acquire),
+            RUNTIME_LOADED | ASSISTANT_COUNT_MASK
+        );
     }
 
     #[test]

--- a/crates/maa-core/src/runtime_lifecycle/runtime.rs
+++ b/crates/maa-core/src/runtime_lifecycle/runtime.rs
@@ -125,7 +125,7 @@ impl Assistant {
         Ok(())
     }
 
-    /// Check if the shared library of the MaaCore is loaded in this thread.
+    /// Check if the shared library of the MaaCore is currently loaded.
     pub fn loaded() -> bool {
         maa_sys::binding::loaded()
     }


### PR DESCRIPTION
## Summary

- Move MaaCore runtime lifecycle coordination into a dedicated `maa-core` lifecycle module with separate runtime-loaded and linked implementations.
- Track runtime state in one atomic word: a `LOCKED` bit for load/unload, a `LOADED` bit for runtime availability, and low bits for active assistant count.
- Reject `Assistant::load()`/`Assistant::unload()` while assistants or runtime changes are active, and reject `Assistant::new()` when the runtime is unloaded or changing.
- Use small RAII tokens only to release the runtime lock or roll back a pending assistant count reservation on construction failure.
- Add regression tests for active assistants, runtime changes, unloaded runtime creation, failed-load lock release, count preservation while locked, and non-runtime builds.

## Why

`Assistant` stores a raw MaaCore handle. Replacing or unloading the runtime-loaded MaaCore library while a handle is alive can leave later FFI calls, including `Drop`, pointing at unloaded code. The safe wrapper now reserves active assistant handles before creating them and blocks runtime replacement or unload while those reservations are alive.

The lock bit does not overwrite the loaded/count state, so existing assistants can still drop and decrement the active count while a runtime change is being rejected or unwound.

## Validation

- `cargo +nightly fmt`
- `cargo test -p maa-core`
- `cargo check -p maa-core --no-default-features`
- `cargo clippy`
- `cargo x test`

## Summary by Sourcery

通过集中管理生命周期跟踪并强制执行安全不变式，保护 MaaCore 运行时时期在并发加载、卸载和助手创建过程中的生命周期安全。

Bug 修复：
- 防止在有 Assistant 实例存活或正在创建时卸载或重新加载 MaaCore 运行时，从而避免对已卸载 FFI 句柄的使用（use-after-unload）。

增强功能：
- 引入专用的运行时生命周期模块，使用原子状态跟踪运行时加载状态和活跃助手数量。
- 通过轻量级 RAII 注册令牌将 Assistant 的创建与运行时加载状态绑定，确保在失败时正确回滚计数。
- 在保持相同 Assistant 接口的前提下，提供分离的“运行时已加载版”和“静态链接版” MaaCore 生命周期 API 实现。

测试：
- 新增单元测试，覆盖：活跃助手阻止运行时变更、在运行时状态迁移或未加载状态下的请求拒绝、失败时锁状态保持，以及非运行时构建场景。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Guard MaaCore runtime lifecycle against concurrent loads, unloads, and assistant creation by centralizing lifecycle tracking and enforcing safety invariants.

Bug Fixes:
- Prevent unloading or reloading the MaaCore runtime while Assistant instances are alive or being created, avoiding use-after-unload of FFI handles.

Enhancements:
- Introduce a dedicated runtime lifecycle module with atomic state tracking for runtime load status and active assistant count.
- Gate Assistant creation on runtime load state using lightweight RAII registration tokens that ensure counts are rolled back on failure.
- Provide separate runtime-loaded and linked implementations of the MaaCore lifecycle API while preserving the same Assistant interface.

Tests:
- Add unit tests covering active-assistant blocking of runtime changes, rejection during runtime transitions or unloaded state, lock-state preservation on failures, and non-runtime builds.

</details>