### PR TITLE
ci: split Windows into separate build and coverage jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,6 @@ jobs:
           - ubuntu-22.04
           - ubuntu-22.04-arm
           - macos-latest
-          - windows-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -87,9 +86,22 @@ jobs:
         uses: Swatinem/rust-cache@v2
       - name: Test
         run: |
-          # TODO: Re-enable macOS Core-backed tests once beta releases ship macOS MaaCore assets again.
-          cargo x test --clippy \
-            ${{ matrix.runner != 'macos-latest' && '--install-core' || '--no-core-tests' }}
+          cargo x test --clippy  --install-core
+
+  build-windows:
+    name: Build and Test (Windows, ${{ matrix.runner }})
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      matrix:
+        runner:
+          - windows-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Setup Cache
+        uses: Swatinem/rust-cache@v2
+      - name: Test
+        run: cargo x test --clippy --install-core
 
   build-tier2:
     name: Build and Test (Tier 2, ${{ matrix.runner }})
@@ -167,7 +179,6 @@ jobs:
         os:
           - ubuntu-22.04
           - macos-latest
-          - windows-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -177,9 +188,27 @@ jobs:
           tool: cargo-llvm-cov
       - name: Coverage
         run: |
-          # TODO: Re-enable macOS Core-backed tests once beta releases ship macOS MaaCore assets again.
-          cargo x test --coverage all \
-            ${{ matrix.os != 'macos-latest' && '--install-core' || '--no-core-tests' }}
+          cargo x test --coverage all --install-core
+      - name: Upload to Codecov
+        uses: codecov/codecov-action@v6
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: codecov.json
+          fail_ci_if_error: true
+
+  coverage-windows:
+    name: Coverage (Windows)
+    needs: [build-windows]
+    runs-on: windows-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-llvm-cov
+      - name: Coverage
+        run: cargo x test --coverage all --install-core
       - name: Upload to Codecov
         uses: codecov/codecov-action@v6
         with:


### PR DESCRIPTION
As they are so slow

## 由 Sourcery 提供的摘要

将 Windows CI 拆分为专门的构建和覆盖率任务，以减少与其他平台的争用，并在启用 install-core 的情况下持续运行基于 core 的测试。

CI：
- 将 Windows 从主构建和覆盖率矩阵中移除，并新增仅针对 Windows 的独立构建和覆盖率任务。
- 简化测试和覆盖率的调用方式，始终在启用 core 安装的情况下运行，而不是跳过 macOS 的 core 测试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Split Windows CI into dedicated build and coverage jobs to reduce contention with other platforms and consistently run core-backed tests with install-core enabled.

CI:
- Remove Windows from the main build and coverage matrices and introduce separate Windows-only build and coverage jobs.
- Simplify test and coverage invocations to always run with core installation enabled instead of skipping macOS core tests.

</details>