### PR TITLE
fix: prefer open by path over bundle id on macOS

### DIFF
--- a/crates/maa-cli/src/run/external/playcover.rs
+++ b/crates/maa-cli/src/run/external/playcover.rs
@@ -1,7 +1,7 @@
-use std::net::TcpStream;
+use std::{env, net::TcpStream};
 
 use anyhow::{Context, Result, bail};
-use log::{info, trace};
+use log::{info, trace, warn};
 
 use crate::config::task::ClientType;
 
@@ -39,14 +39,34 @@ impl super::ExternalApp for PlayCoverApp<'_> {
             .bundle_id()
             .with_context(|| format!("Client {} is not available on the App Store", self.client))?;
 
-        info!("Starting app: {bundle_id}");
-        let status = std::process::Command::new("open")
-            .arg("-b")
-            .arg(bundle_id)
-            .status()
-            .context("Failed to start game!")?;
-        if !status.success() {
-            bail!("Failed to start game with bundle identifier {bundle_id}: {status}");
+        let success = if let Some(home) = env::home_dir() {
+            info!("Starting app: {bundle_id} by path");
+            std::process::Command::new("open")
+                .arg("-a")
+                .arg(
+                    home.join("Library")
+                        .join("Containers")
+                        .join("io.playcover.PlayCover")
+                        .join("Applications")
+                        .join(format!("{bundle_id}.app")),
+                )
+                .status()
+                .context("Failed to start game!")?
+                .success()
+        } else {
+            false
+        };
+        if !success {
+            warn!("Failed to start game by path, fall back to bundle id");
+            info!("Starting app: {bundle_id} by bundle id");
+            let status = std::process::Command::new("open")
+                .arg("-b")
+                .arg(bundle_id)
+                .status()
+                .context("Failed to start game!")?;
+            if !status.success() {
+                bail!("Failed to start game with bundle identifier {bundle_id}: {status}");
+            }
         }
 
         // Wait for game ready


### PR DESCRIPTION
When there are multiple installations on macOS, `open -b` might open an unintended installation. PlayCover's app path is `~/Library/Containers/io.playcover.PlayCover/Applications/{bundle_id}.app` by default. Try open by path before falling back to bundle id.

## Summary by Sourcery

Bug Fixes:
- 为避免在 macOS 上意外启动错误的 PlayCover 安装版本，首先尝试从其容器路径打开应用；如果失败，再回退到使用 bundle identifier 来启动。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Avoid accidentally launching the wrong PlayCover installation on macOS by trying to open the app from its container path first and only falling back to the bundle identifier if that fails.

</details>