### PR TITLE
feat: add support for MaaFwWlr touch mode

### DIFF
--- a/crates/maa-cli/schemas/asst.schema.json
+++ b/crates/maa-cli/schemas/asst.schema.json
@@ -77,7 +77,7 @@
     },
     "touchMode": {
       "type": "string",
-      "enum": ["ADB", "MiniTouch", "MaaTouch", "MacPlayTools", "MaaFwAdb"],
+      "enum": ["ADB", "MiniTouch", "MaaTouch", "MacPlayTools", "MaaFwAdb", "MaaFwWlr"],
       "default": "ADB"
     }
   }

--- a/crates/maa-cli/src/config/init.rs
+++ b/crates/maa-cli/src/config/init.rs
@@ -67,6 +67,10 @@ fn asst_config_template() -> MAAValueTemplate {
                         "MaaFwAdb",
                         Some("use MaaFramework ADB controller for emulator extras support"),
                     ),
+                    ValueWithDesc::new(
+                        "MaaFwWlr",
+                        Some("use MaaFramework wlroots controller for wayland support"),
+                    ),
                 ],
                 std::num::NonZero::new(3),
             ).unwrap()

--- a/crates/maa-types/src/touch_mode.rs
+++ b/crates/maa-types/src/touch_mode.rs
@@ -19,10 +19,12 @@ pub enum TouchMode {
     /// A MaaFramework-based ADB controller that enables emulator-specific fast screencap support,
     /// such as Android Emulator AVD extras.
     MaaFwAdb,
+    /// A MaaFramework-based wlroots touch controller, which controls through the Wayland protocol.
+    MaaFwWlr,
 }
 
 impl TouchMode {
-    impl_enum_utils!(TouchMode, 5, TouchMode::Adb);
+    impl_enum_utils!(TouchMode, 6, TouchMode::Adb);
 
     impl_from_str_opt!();
 
@@ -34,6 +36,7 @@ impl TouchMode {
             TouchMode::MaaTouch => "maatouch",
             TouchMode::MacPlayTools => "MacPlayTools",
             TouchMode::MaaFwAdb => "MaaFwAdb",
+            TouchMode::MaaFwWlr => "MaaFwWlr",
         }
     }
 }
@@ -75,6 +78,8 @@ mod tests {
         assert_eq!("MacPlayTools".parse(), Ok(TouchMode::MacPlayTools));
         assert_eq!("maafwadb".parse(), Ok(TouchMode::MaaFwAdb));
         assert_eq!("MaaFwAdb".parse(), Ok(TouchMode::MaaFwAdb));
+        assert_eq!("maafwwlr".parse(), Ok(TouchMode::MaaFwWlr));
+        assert_eq!("MaaFwWlr".parse(), Ok(TouchMode::MaaFwWlr));
 
         assert_eq!(
             "Unknown".parse::<TouchMode>(),
@@ -82,7 +87,7 @@ mod tests {
         );
         assert_eq!(
             UnknownTouchModeError("Unknown".to_owned()).to_string(),
-            "unknown touch mode `Unknown`, expected one of `adb`, `minitouch`, `maatouch`, `MacPlayTools`, `MaaFwAdb`",
+            "unknown touch mode `Unknown`, expected one of `adb`, `minitouch`, `maatouch`, `MacPlayTools`, `MaaFwAdb`, `MaaFwWlr`",
         );
     }
 
@@ -100,6 +105,7 @@ mod tests {
                 TouchMode::MaaTouch,
                 TouchMode::MacPlayTools,
                 TouchMode::MaaFwAdb,
+                TouchMode::MaaFwWlr,
             ];
 
             // Test deserializing from string
@@ -110,6 +116,7 @@ mod tests {
                 Token::Str("maatouch"),
                 Token::Str("MacPlayTools"),
                 Token::Str("MaaFwAdb"),
+                Token::Str("MaaFwWlr"),
                 Token::SeqEnd,
             ]);
         }
@@ -119,7 +126,7 @@ mod tests {
             assert_de_tokens_error::<TouchMode>(
                 &[Token::Str("Unknown")],
                 "unknown variant `Unknown`, expected one of \
-                `adb`, `minitouch`, `maatouch`, `MacPlayTools`, `MaaFwAdb`",
+                `adb`, `minitouch`, `maatouch`, `MacPlayTools`, `MaaFwAdb`, `MaaFwWlr`",
             );
 
             assert_de_tokens_error::<TouchMode>(
@@ -135,6 +142,7 @@ mod tests {
             assert_ser_tokens(&TouchMode::MaaTouch, &[Token::Str("maatouch")]);
             assert_ser_tokens(&TouchMode::MacPlayTools, &[Token::Str("MacPlayTools")]);
             assert_ser_tokens(&TouchMode::MaaFwAdb, &[Token::Str("MaaFwAdb")]);
+            assert_ser_tokens(&TouchMode::MaaFwWlr, &[Token::Str("MaaFwWlr")]);
         }
     }
 
@@ -145,6 +153,7 @@ mod tests {
         assert_eq!(TouchMode::MaaTouch.to_str(), "maatouch");
         assert_eq!(TouchMode::MacPlayTools.to_str(), "MacPlayTools");
         assert_eq!(TouchMode::MaaFwAdb.to_str(), "MaaFwAdb");
+        assert_eq!(TouchMode::MaaFwWlr.to_str(), "MaaFwWlr");
     }
 
     #[cfg(feature = "ffi")]


### PR DESCRIPTION
- https://github.com/MaaAssistantArknights/MaaAssistantArknights/pull/17039

```toml
[connection]
address = "/run/user/1000/wayland-0"

[instance_options]
touch_mode = "MaaFwWlr"
```

## Summary by Sourcery

在触摸模式枚举中新增一个基于 MaaFramework 的 wlroots 触摸模式，并确保在解析、序列化以及测试中获得完整支持。

新功能：
- 引入用于 Wayland wlroots 触控控制的 `MaaFwWlr` 触摸模式变体。

测试：
- 扩展解析、序列化以及错误信息相关测试，以覆盖新的 `MaaFwWlr` 触摸模式。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a new MaaFramework-based wlroots touch mode to the touch mode enumeration and ensure it is fully supported across parsing, serialization, and tests.

New Features:
- Introduce the MaaFwWlr touch mode variant for Wayland wlroots-based touch control.

Tests:
- Extend parsing, serialization, and error message tests to cover the new MaaFwWlr touch mode.

</details>