### PR TITLE
fix: use case sensitive YoStar

### DIFF
--- a/crates/maa-cli/src/config/init.rs
+++ b/crates/maa-cli/src/config/init.rs
@@ -93,15 +93,15 @@ fn asst_config_template() -> MAAValueTemplate {
                         Some("no global resource needed by Official and BiliBili client"),
                     ),
                     ValueWithDesc::new(
-                        "YostarJP",
-                        Some("resource fror Japanese client"),
+                        "YoStarJP",
+                        Some("resource for Japanese client"),
                     ),
                     ValueWithDesc::new(
-                        "YostarKR",
+                        "YoStarKR",
                         Some("resource for Korean client"),
                     ),
                     ValueWithDesc::new(
-                        "YostarEN",
+                        "YoStarEN",
                         Some("resource for English client"),
                     ),
                     ValueWithDesc::new(


### PR DESCRIPTION
## Summary by Sourcery

错误修复：
- 修正配置模板中 YoStarJP、YoStarKR 和 YoStarEN 资源选项的大小写和拼写问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix case and spelling of YoStarJP, YoStarKR, and YoStarEN resource options in the configuration template.

</details>