### PR TITLE
feat: allow disabling API hot updates

### DIFF
--- a/crates/maa-cli/config_examples/cli.toml
+++ b/crates/maa-cli/config_examples/cli.toml
@@ -65,6 +65,8 @@ passphrase = "password"  # Passphrase of ssh key
 # Note: this is different from `resource`, this is for hot update of activity files
 # and resource files from MAA API, while `resource` is for resource repository
 [hot_update]
+# Whether to update activity and API resource files before running tasks
+auto_update = true
 # URL of the hot update API, used to get activity and hot update resource files
 api_url = "https://github.com/MaaAssistantArknights/MaaRelease/raw/main/MaaAssistantArknights/api"
 # Check interval in seconds, files will be re-downloaded if older than this interval

--- a/crates/maa-cli/docs/en-US/config.md
+++ b/crates/maa-cli/docs/en-US/config.md
@@ -448,6 +448,14 @@ passphrase = "password" # Passphrase for SSH key
 # passphrase = { env = "MAA_SSH_PASSPHRASE" }
 # 3. Use a command output (useful with password managers)
 # passphrase = { cmd = ["pass", "show", "ssh/id_ed25519"] }
+
+# Activity and API resource file hot update configurations
+[hot_update]
+auto_update = true # Whether to update these files before running tasks
+# API URL for activity and hot update resource files
+api_url = "https://api.maa.plus/MaaAssistantArknights/api"
+# Cache lifetime in seconds; 0 means always download
+check_interval = 600
 ```
 
 **NOTE**:

--- a/crates/maa-cli/docs/zh-CN/config.md
+++ b/crates/maa-cli/docs/zh-CN/config.md
@@ -437,6 +437,14 @@ passphrase = "password"       # ssh 密钥的密码
 # ssh-agent 会将你的密钥保存在内存中，这样你就不需要每次输入密码
 # 注意，你需要确保 ssh-agent 已经启动并且已经添加了你的密钥，同时 SSH_AUTH_SOCK 环境变量已经设置
 # use_ssh_agent = true # 使用 ssh-agent 进行身份验证，如果设置为 true，将忽略 ssh_key 和 passphrase 字段
+
+# 活动数据和 API 资源文件热更新相关配置
+[hot_update]
+auto_update = true # 是否在运行任务前更新这些文件
+# 活动数据和热更新资源文件的 API 地址
+api_url = "https://api.maa.plus/MaaAssistantArknights/api"
+# 缓存有效期，单位为秒；设置为 0 表示每次都下载
+check_interval = 600
 ```
 
 **注意事项**：

--- a/crates/maa-cli/schemas/cli.schema.json
+++ b/crates/maa-cli/schemas/cli.schema.json
@@ -49,6 +49,14 @@
           }
         }
       }
+    },
+    "hot_update": {
+      "type": "object",
+      "properties": {
+        "auto_update": { "type": "boolean", "default": true },
+        "api_url": { "type": "string", "format": "uri" },
+        "check_interval": { "type": "integer", "minimum": 0, "default": 600 }
+      }
     }
   },
   "definitions": {

--- a/crates/maa-cli/src/config/cli/hot_update.rs
+++ b/crates/maa-cli/src/config/cli/hot_update.rs
@@ -3,11 +3,13 @@ use std::path::{Path, PathBuf};
 use rayon::iter::{IndexedParallelIterator, IntoParallelRefIterator, ParallelIterator};
 use serde::Deserialize;
 
-use crate::config::cli::normalize_url;
+use crate::config::cli::{normalize_url, return_true};
 
 #[cfg_attr(test, derive(Debug, PartialEq))]
 #[derive(Deserialize, Clone)]
 pub struct Config {
+    #[serde(default = "return_true")]
+    auto_update: bool,
     #[serde(default = "default_api_url")]
     api_url: String,
     /// Check interval in seconds (0 to disable caching)
@@ -18,6 +20,7 @@ pub struct Config {
 impl Default for Config {
     fn default() -> Self {
         Self {
+            auto_update: true,
             api_url: default_api_url(),
             check_interval: default_check_interval(),
         }
@@ -41,6 +44,10 @@ impl Config {
         &["global", "YoStarKR", "resource"],
         &["global", "txwy", "resource"],
     ];
+
+    pub fn auto_update(&self) -> bool {
+        self.auto_update
+    }
 
     pub fn api_url(&self) -> &str {
         normalize_url(&self.api_url)
@@ -114,6 +121,7 @@ pub mod tests {
 
     pub fn example_config() -> Config {
         Config {
+            auto_update: true,
             api_url: "https://github.com/MaaAssistantArknights/MaaRelease/raw/main/MaaAssistantArknights/api".to_string(),
             check_interval: 3600, // 1 hour
         }
@@ -123,6 +131,7 @@ pub mod tests {
     fn default() {
         let config = Config::default();
         assert_eq!(config, Config {
+            auto_update: true,
             api_url: default_api_url(),
             check_interval: default_check_interval(),
         });
@@ -145,7 +154,7 @@ pub mod tests {
             assert_de_tokens(
                 &Config {
                     api_url: "https://custom.api.com".to_string(),
-                    check_interval: default_check_interval(),
+                    ..Default::default()
                 },
                 &[
                     Token::Map { len: Some(1) },
@@ -158,8 +167,8 @@ pub mod tests {
             // Custom check_interval
             assert_de_tokens(
                 &Config {
-                    api_url: default_api_url(),
                     check_interval: 3600, // 1 hour
+                    ..Default::default()
                 },
                 &[
                     Token::Map { len: Some(1) },
@@ -174,6 +183,7 @@ pub mod tests {
                 &Config {
                     api_url: "https://custom.api.com".to_string(),
                     check_interval: 0, // Disable caching
+                    ..Default::default()
                 },
                 &[
                     Token::Map { len: Some(2) },
@@ -184,11 +194,37 @@ pub mod tests {
                     Token::MapEnd,
                 ],
             );
+
+            // Disable automatic API hot update
+            assert_de_tokens(
+                &Config {
+                    auto_update: false,
+                    ..Default::default()
+                },
+                &[
+                    Token::Map { len: Some(1) },
+                    Token::Str("auto_update"),
+                    Token::Bool(false),
+                    Token::MapEnd,
+                ],
+            );
         }
     }
 
     mod methods {
         use super::*;
+
+        #[test]
+        fn auto_update() {
+            assert!(Config::default().auto_update());
+            assert!(
+                !Config {
+                    auto_update: false,
+                    ..Default::default()
+                }
+                .auto_update()
+            );
+        }
 
         #[test]
         fn resource_files() {

--- a/crates/maa-cli/src/run/mod.rs
+++ b/crates/maa-cli/src/run/mod.rs
@@ -22,6 +22,7 @@ use crate::{
     config::{
         FindFile,
         asst::AsstConfig,
+        cli::CLI_CONFIG,
         task::{TaskConfig, TaskConfigTemplate},
     },
     installer,
@@ -127,7 +128,9 @@ where
     F: FnOnce(&AsstConfig) -> Result<TaskConfig>,
 {
     // Auto update hot update resource
-    installer::hot_update::update()?;
+    if CLI_CONFIG.hot_update_config().auto_update() {
+        installer::hot_update::update()?;
+    }
     installer::resource::update(true)?;
 
     // Load asst config


### PR DESCRIPTION
## Summary

- add `hot_update.auto_update`, defaulting to `true` for backward compatibility
- skip the automatic API hot update before task execution when the option is disabled
- keep the explicit `maa hot-update` command unchanged
- document the setting in the example config, JSON Schema, Simplified Chinese docs, and English docs

## Motivation

`run_core` currently calls the activity/API resource hot updater before every task, including `--dry-run`. If `api.maa.plus` is unreachable or a connection is reset, task parsing and device automation abort before MaaCore can run. The existing `resource.auto_update` option only controls the Git-backed MaaResource updater, so it cannot disable these API requests.

This was reproduced on Windows with maa-cli 0.7.5: both dry-run and a StartUp-only task failed during the API hot update. With this patch and `hot_update.auto_update = false`, dry-run completes without an update request.

## Impact

Existing users keep the current behavior because the new setting defaults to `true`. Users on offline or restricted networks can disable automatic API updates and run `maa hot-update` explicitly when connectivity is available.

## Checks

- `cargo +nightly fmt`
- `cargo clippy -p maa-cli --all-targets --offline`
- `cargo x test --no-core-tests --no-ignored-tests --package maa-cli` (306 passed, 26 ignored)
- parsed the updated example TOML and JSON Schema locally

## Summary by Sourcery

引入一个可配置的开关，用于控制自动活动/API 热更新，并将其接入任务执行流程，默认行为保持现有逻辑不变。

New Features:
- 新增 `hot_update.auto_update` CLI 配置项，用于在运行任务前启用或禁用活动和 API 资源的自动热更新。

Enhancements:
- 在任务执行中，将自动 API 热更新受新的配置开关控制，从而可以关闭自动更新，同时保持手动热更新命令的行为不变。

Documentation:
- 在示例 CLI 配置、JSON Schema，以及英文和简体中文的配置指南中记录 `hot_update.auto_update` 设置。

Tests:
- 扩展配置相关测试，覆盖新的 `hot_update.auto_update` 字段及其默认值和显式配置值。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a configurable switch to control automatic activity/API hot updates and wire it into task execution, with defaults preserving existing behavior.

New Features:
- Add a hot_update.auto_update CLI configuration option to enable or disable automatic activity and API resource hot updates before running tasks.

Enhancements:
- Gate the automatic API hot update in task execution on the new configuration flag so it can be disabled while keeping manual hot-update commands unchanged.

Documentation:
- Document the hot_update.auto_update setting in the example CLI config, JSON Schema, and both English and Simplified Chinese configuration guides.

Tests:
- Extend configuration tests to cover the new hot_update.auto_update field and its default/explicit values.

</details>