### PR TITLE
docs: fix cargo install commands

### DIFF
--- a/crates/maa-cli/docs/en-US/install.md
+++ b/crates/maa-cli/docs/en-US/install.md
@@ -69,13 +69,13 @@ Rust developers can compile and install maa-cli themselves via `cargo`:
 - Stable version:
 
   ```bash
-  cargo install --git https://github.com/MaaAssistantArknights/maa-cli.git --bin maa --tag stable --locked
+  cargo install maa-cli --git https://github.com/MaaAssistantArknights/maa-cli.git --bin maa --tag stable --locked
   ```
 
 - Development version:
 
   ```bash
-  cargo install --git https://github.com/MaaAssistantArknights/maa-cli.git --bin maa --locked
+  cargo install maa-cli --git https://github.com/MaaAssistantArknights/maa-cli.git --bin maa --locked
   ```
 
 ### Features

--- a/crates/maa-cli/docs/ja-JP/install.md
+++ b/crates/maa-cli/docs/ja-JP/install.md
@@ -73,13 +73,13 @@ Rust 开发者可以通过 `cargo` 自行编译安装 maa-cli：
 - 稳定版本：
 
   ```bash
-  cargo install --git https://github.com/MaaAssistantArknights/maa-cli.git --bin maa --tag stable --locked
+  cargo install maa-cli --git https://github.com/MaaAssistantArknights/maa-cli.git --bin maa --tag stable --locked
   ```
 
 - 开发版本：
 
   ```bash
-  cargo install --git https://github.com/MaaAssistantArknights/maa-cli.git --bin maa --locked
+  cargo install maa-cli --git https://github.com/MaaAssistantArknights/maa-cli.git --bin maa --locked
   ```
 
 ### 编译选项

--- a/crates/maa-cli/docs/ko-KR/install.md
+++ b/crates/maa-cli/docs/ko-KR/install.md
@@ -73,13 +73,13 @@ Rust 개발자는 `cargo`를 통해 maa-cli를 직접 컴파일하여 설치할 
 - 안정 버전:
 
   ```bash
-  cargo install --git https://github.com/MaaAssistantArknights/maa-cli.git --bin maa --tag stable --locked
+  cargo install maa-cli --git https://github.com/MaaAssistantArknights/maa-cli.git --bin maa --tag stable --locked
   ```
 
 - 개발 버전:
 
   ```bash
-  cargo install --git https://github.com/MaaAssistantArknights/maa-cli.git --bin maa --locked
+  cargo install maa-cli --git https://github.com/MaaAssistantArknights/maa-cli.git --bin maa --locked
   ```
 
 ### 컴파일 옵션

--- a/crates/maa-cli/docs/zh-CN/install.md
+++ b/crates/maa-cli/docs/zh-CN/install.md
@@ -93,13 +93,13 @@ Rust 开发者可以通过 `cargo` 自行编译安装 maa-cli：
 - 稳定版本：
 
   ```bash
-  cargo install --git https://github.com/MaaAssistantArknights/maa-cli.git --bin maa --tag stable --locked
+  cargo install maa-cli --git https://github.com/MaaAssistantArknights/maa-cli.git --bin maa --tag stable --locked
   ```
 
 - 开发版本：
 
   ```bash
-  cargo install --git https://github.com/MaaAssistantArknights/maa-cli.git --bin maa --locked
+  cargo install maa-cli --git https://github.com/MaaAssistantArknights/maa-cli.git --bin maa --locked
   ```
 
 ### 编译选项

--- a/crates/maa-cli/docs/zh-TW/install.md
+++ b/crates/maa-cli/docs/zh-TW/install.md
@@ -73,13 +73,13 @@ Rust 开发者可以通过 `cargo` 自行编译安装 maa-cli：
 - 稳定版本：
 
   ```bash
-  cargo install --git https://github.com/MaaAssistantArknights/maa-cli.git --bin maa --tag stable --locked
+  cargo install maa-cli --git https://github.com/MaaAssistantArknights/maa-cli.git --bin maa --tag stable --locked
   ```
 
 - 开发版本：
 
   ```bash
-  cargo install --git https://github.com/MaaAssistantArknights/maa-cli.git --bin maa --locked
+  cargo install maa-cli --git https://github.com/MaaAssistantArknights/maa-cli.git --bin maa --locked
   ```
 
 ### 编译选项


### PR DESCRIPTION
## 修改内容

- 修复 `cargo install` 示例未指定 `maa-cli` package 的问题。
- 同步更新中、英、日、韩、繁中安装文档。

`maa-cli` 所在仓库是多 package workspace；未指定 package 时，Cargo 无法确定要安装哪个包。

## 验证

- 在隔离目录执行以下命令并成功安装、运行 `maa 0.7.5`：

  ```bash
  cargo install maa-cli --git https://github.com/MaaAssistantArknights/maa-cli.git --bin maa --tag stable --locked
  ```

- `git diff --check`

## Summary by Sourcery

文档：
- 更新英文、简体中文、繁体中文、日文和韩文的安装文档，在 Cargo 示例中明确说明需要安装 `maa-cli` 包。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Update English, Chinese (Simplified and Traditional), Japanese, and Korean installation docs to explicitly install the maa-cli package in cargo examples.

</details>