### PR TITLE
fix(maa-dirs): treat empty directory environment variables as unset

### DIFF
--- a/crates/maa-dirs/src/lib.rs
+++ b/crates/maa-dirs/src/lib.rs
@@ -84,11 +84,16 @@ impl VarOs for EnvVarOs {
 /// The `maa_env` usually is `MAA_XXX_DIR`, and the `xdg_env` usually is `XDG_XXX_HOME`.
 /// If the `maa_env` is set, return the directory `maa_env`.
 /// If the `xdg_env` is set, return the directory `xdg_env/maa`.
-/// Otherwise, return `None`.
+/// Empty values are treated as unset; otherwise, return `None`.
 fn dir_from_env(v: impl VarOs + Copy, maa_env: &str, xdg_env: &str) -> Option<PathBuf> {
     v.var_os(maa_env)
+        .filter(|value| !value.is_empty())
         .map(PathBuf::from)
-        .or_else(|| v.var_os(xdg_env).map(|xdg| join!(xdg, "maa")))
+        .or_else(|| {
+            v.var_os(xdg_env)
+                .filter(|value| !value.is_empty())
+                .map(|xdg| join!(xdg, "maa"))
+        })
 }
 
 /// Get the data directory.
@@ -682,6 +687,35 @@ mod tests {
             assert_eq!(dirs.library(), PathBuf::from("/maa/lib"));
             assert_eq!(dirs.resource(), PathBuf::from("/maa/resource"));
             assert_eq!(dirs.maa_resource(), PathBuf::from("/maa/MaaResource"));
+        }
+
+        #[test]
+        fn empty_env_dirs_are_ignored() {
+            // An empty MAA-specific override should fall back to its XDG counterpart.
+            let mock = MockVarOs::new()
+                .with_var("MAA_DATA_DIR", "")
+                .with_var("XDG_DATA_HOME", "/xdg");
+            let dirs = Dirs::new_inner(PROJECT.as_ref(), &mock);
+            assert_eq!(dirs.data(), PathBuf::from("/xdg/maa"));
+
+            // Empty variables should behave the same as unset variables.
+            let expected = Dirs::new_inner(PROJECT.as_ref(), &MockVarOs::new());
+            let mock = MockVarOs::from(vec![
+                ("MAA_DATA_DIR", ""),
+                ("XDG_DATA_HOME", ""),
+                ("MAA_STATE_DIR", ""),
+                ("XDG_STATE_HOME", ""),
+                ("MAA_CACHE_DIR", ""),
+                ("XDG_CACHE_HOME", ""),
+                ("MAA_CONFIG_DIR", ""),
+                ("XDG_CONFIG_HOME", ""),
+            ]);
+            let dirs = Dirs::new_inner(PROJECT.as_ref(), &mock);
+
+            assert_eq!(dirs.data(), expected.data());
+            assert_eq!(dirs.state(), expected.state());
+            assert_eq!(dirs.cache(), expected.cache());
+            assert_eq!(dirs.config(), expected.config());
         }
 
         #[test]


### PR DESCRIPTION
## 问题描述

`dir_from_env` 当前会将值为空的环境变量视为有效路径。

例如：

```text
XDG_DATA_HOME=
XDG_CACHE_HOME=
```

此时数据目录和缓存目录都可能被解析为相对路径 `maa/`：

```text
data:  maa
cache: maa
```

这会导致 MaaCore 的基础资源目录与热更新缓存目录重合。热更新下载的 `tasks.json` 增量资源可能因此覆盖基础资源中的完整 `tasks.json`，最终导致资源加载失败。

根据 XDG Base Directory Specification，XDG 环境变量未设置或值为空时，都应回退到默认目录。

## 修改内容

- 忽略值为空的 `MAA_*_DIR` 环境变量，并继续尝试对应的 XDG 环境变量。
- 忽略值为空的 `XDG_*_HOME` 环境变量，并回退到平台默认目录。
- 保持非空 `MAA_*_DIR` 优先于 XDG 环境变量的现有行为。
- 添加空环境变量相关的回归测试。

## 测试结果

- `cargo test -p maa-dirs`
- `cargo clippy --workspace --all-targets`
- `cargo x test`
- 验证所有 XDG 变量为空时，数据目录正确解析为 `~/.local/share/maa`，而不是相对路径 `maa/`

## Summary by Sourcery

将与目录相关的空环境变量视为未设置，这样目录解析会回退到 XDG 或平台默认值，而不是使用无效的相对路径。

Bug Fixes:
- 当 `MAA_*_DIR` 或 `XDG_*_HOME` 变量被设置为空字符串时，防止数据、缓存、状态和配置目录解析为意料之外的相对路径。

Tests:
- 添加回归测试，确保空的 `MAA_*_DIR` 和 `XDG_*_HOME` 环境变量会被忽略，并且行为与未设置变量时相同。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Treat empty directory-related environment variables as unset so directory resolution falls back to XDG or platform defaults instead of using invalid relative paths.

Bug Fixes:
- Prevent data, cache, state, and config directories from resolving to unintended relative paths when MAA_*_DIR or XDG_*_HOME variables are set to empty strings.

Tests:
- Add regression tests to ensure empty MAA_*_DIR and XDG_*_HOME environment variables are ignored and behave the same as unset variables.

</details>