### PR TITLE
docs: remove obsolete NUR installation instructions

### DIFF
--- a/crates/maa-cli/docs/en-US/install.md
+++ b/crates/maa-cli/docs/en-US/install.md
@@ -37,12 +37,7 @@ Homebrew users can install maa-cli via the unofficial [tap](https://github.com/M
   nix run nixpkgs#maa-cli
   ```
 
-  ```bash
-  # Nightly build
-  nix run github:Cryolitia/nur-packages#maa-cli-nightly
-  ```
-
-  Stable is packaged in [nixpkgs](https://github.com/NixOS/nixpkgs/blob/nixos-unstable/pkgs/by-name/ma/maa-cli/package.nix), using the nixpkgs Rust toolchain; Nightly is in [NUR](https://github.com/Cryolitia/nur-packages/blob/master/pkgs/maa-assistant-arknights/maa-cli.nix), using the Beta Channel Rust toolchain, automatically updated and built daily by GitHub Actions.
+  The stable release is packaged in [nixpkgs](https://github.com/NixOS/nixpkgs/blob/nixos-unstable/pkgs/by-name/ma/maa-cli/package.nix) and uses the nixpkgs Rust toolchain.
 
 - Users using Homebrew on Linux please refer to the macOS installation method above.
 

--- a/crates/maa-cli/docs/ja-JP/install.md
+++ b/crates/maa-cli/docs/ja-JP/install.md
@@ -41,12 +41,7 @@ Homebrew 用户可以通过非官方的 [tap](https://github.com/MaaAssistantArk
   nix run nixpkgs#maa-cli
   ```
 
-  ```bash
-  # 每夜构建
-  nix run github:Cryolitia/nur-packages#maa-cli-nightly
-  ```
-
-  稳定版打包至 [nixpkgs](https://github.com/NixOS/nixpkgs/blob/nixos-unstable/pkgs/by-name/ma/maa-cli/package.nix) 中，使用 `nixpkgs` 中的 Rust 工具链；每夜构建位于 [NUR](https://github.com/Cryolitia/nur-packages/blob/master/pkgs/maa-assistant-arknights/maa-cli.nix) 中，使用 Beta channel 的 Rust 工具链，由 Github Action 每日自动更新和构建验证。
+  稳定版打包至 [nixpkgs](https://github.com/NixOS/nixpkgs/blob/nixos-unstable/pkgs/by-name/ma/maa-cli/package.nix) 中，使用 `nixpkgs` 中的 Rust 工具链。
 
 - 对于在 Linux 上使用 Homebrew 的用户，参见上述 macOS 的安装方式。
 

--- a/crates/maa-cli/docs/ko-KR/install.md
+++ b/crates/maa-cli/docs/ko-KR/install.md
@@ -41,12 +41,7 @@ Homebrew 사용자는 비공식 [tap](https://github.com/MaaAssistantArknights/h
   nix run nixpkgs#maa-cli
   ```
 
-  ```bash
-  # 매일 최신화 버전
-  nix run github:Cryolitia/nur-packages#maa-cli-nightly
-  ```
-
-  안정 버전은 [nixpkgs](https://github.com/NixOS/nixpkgs/blob/nixos-unstable/pkgs/by-name/ma/maa-cli/package.nix)에 포함되어 있으며, `nixpkgs`의 Rust 도구 체인을 사용합니다. 매일 빌드는 [NUR](https://github.com/Cryolitia/nur-packages/blob/master/pkgs/maa-assistant-arknights/maa-cli.nix)에 위치하며, Beta 채널의 Rust 도구 체인을 사용하고 GitHub Action을 통해 매일 자동으로 업데이트 및 빌드 검증을 수행합니다.
+  안정 버전은 [nixpkgs](https://github.com/NixOS/nixpkgs/blob/nixos-unstable/pkgs/by-name/ma/maa-cli/package.nix)에 포함되어 있으며, `nixpkgs`의 Rust 도구 체인을 사용합니다.
 
 - Linux에서 Homebrew를 사용하는 경우 위의 macOS 설치 방법을 참조하세요.
 

--- a/crates/maa-cli/docs/zh-CN/install.md
+++ b/crates/maa-cli/docs/zh-CN/install.md
@@ -37,12 +37,7 @@ Homebrew 用户可以通过非官方的 [tap](https://github.com/MaaAssistantArk
   nix run nixpkgs#maa-cli
   ```
 
-  ```bash
-  # 每夜构建
-  nix run github:Cryolitia/nur-packages#maa-cli-nightly
-  ```
-
-  稳定版打包至 [nixpkgs](https://github.com/NixOS/nixpkgs/blob/nixos-unstable/pkgs/by-name/ma/maa-cli/package.nix) 中，使用 `nixpkgs` 中的 Rust 工具链；每夜构建位于 [NUR](https://github.com/Cryolitia/nur-packages/blob/master/pkgs/maa-assistant-arknights/maa-cli.nix) 中，使用 Beta channel 的 Rust 工具链，由 Github Action 每日自动更新和构建验证。
+  稳定版打包至 [nixpkgs](https://github.com/NixOS/nixpkgs/blob/nixos-unstable/pkgs/by-name/ma/maa-cli/package.nix) 中，使用 `nixpkgs` 中的 Rust 工具链。
 
 - 对于在 Linux 上使用 Homebrew 的用户，参见上述 macOS 的安装方式。
 

--- a/crates/maa-cli/docs/zh-TW/install.md
+++ b/crates/maa-cli/docs/zh-TW/install.md
@@ -41,12 +41,7 @@ Homebrew 用户可以通过非官方的 [tap](https://github.com/MaaAssistantArk
   nix run nixpkgs#maa-cli
   ```
 
-  ```bash
-  # 每夜构建
-  nix run github:Cryolitia/nur-packages#maa-cli-nightly
-  ```
-
-  稳定版打包至 [nixpkgs](https://github.com/NixOS/nixpkgs/blob/nixos-unstable/pkgs/by-name/ma/maa-cli/package.nix) 中，使用 `nixpkgs` 中的 Rust 工具链；每夜构建位于 [NUR](https://github.com/Cryolitia/nur-packages/blob/master/pkgs/maa-assistant-arknights/maa-cli.nix) 中，使用 Beta channel 的 Rust 工具链，由 Github Action 每日自动更新和构建验证。
+  稳定版打包至 [nixpkgs](https://github.com/NixOS/nixpkgs/blob/nixos-unstable/pkgs/by-name/ma/maa-cli/package.nix) 中，使用 `nixpkgs` 中的 Rust 工具链。
 
 - 对于在 Linux 上使用 Homebrew 的用户，参见上述 macOS 的安装方式。
 


### PR DESCRIPTION
## Summary

Remove the obsolete NUR nightly installation instructions after the upstream NUR repository dropped the MAA package.

## Changes

- Remove the unavailable `maa-cli-nightly` Nix command from all localized installation guides.
- Remove the deleted NUR package link while retaining the supported nixpkgs stable installation.

## Validation

- `markdownlint-cli2 --config .markdownlint.yaml '**/*.md'`
- `typos`
- `git diff --check`

## Stack

- Follow-up PR: #566
- The repository-wide Dead Links check on this PR may still report the independent changelog link fixed by #566.