### PR TITLE
fix(changelog): exclude automated changelog commits

### DIFF
--- a/.github/workflows/publish-changelog.yml
+++ b/.github/workflows/publish-changelog.yml
@@ -70,5 +70,5 @@ jobs:
         if: ${{ !inputs.dryrun }}
         run: |
           git add CHANGELOG.md
-          git commit -m "chore(Changelog): update changelog for ${{ inputs.version }}"
+          git commit -m "chore(changelog): update changelog for ${{ inputs.version }}"
           git push

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,8 +21,6 @@
 
 - Bump tar from 0.4.45 to 0.4.46 by [@dependabot](https://github.com/dependabot) in [#551](https://github.com/MaaAssistantArknights/maa-cli/pull/551)
 
-### Miscellaneous
-
 **Full Changelog**: <https://github.com/MaaAssistantArknights/maa-cli/compare/v0.7.4...v0.7.5>
 
 ## Release 0.7.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,8 +23,6 @@
 
 ### Miscellaneous
 
-- Update changelog for 0.7.4 by [@github-actions](https://github.com/github-actions)
-
 **Full Changelog**: <https://github.com/MaaAssistantArknights/maa-cli/compare/v0.7.4...v0.7.5>
 
 ## Release 0.7.4

--- a/cliff.toml
+++ b/cliff.toml
@@ -128,7 +128,7 @@ commit_parsers = [
   { message = "^chore\\(xtask\\)", skip = true },
 
   # skip changelog commits
-  { message = "(?i)^chore(?:\\(changelog\\))?: update changelog", skip = true },
+  { message = "(?i)^chore(?:\\(changelog\\))?: update changelog(?: for \\S+)?$", skip = true },
 
   # chore should be the last one to avoid overriding above rules
   { message = "^chore", group = "<!-- 99 -->Miscellaneous" },

--- a/cliff.toml
+++ b/cliff.toml
@@ -128,8 +128,7 @@ commit_parsers = [
   { message = "^chore\\(xtask\\)", skip = true },
 
   # skip changelog commits
-  { message = "^chore\\(changelog\\)", skip = true },
-  { message = "^chore: update changelog", skip = true },
+  { message = "(?i)^chore(?:\\(changelog\\))?: update changelog", skip = true },
 
   # chore should be the last one to avoid overriding above rules
   { message = "^chore", group = "<!-- 99 -->Miscellaneous" },


### PR DESCRIPTION
## Summary

Prevent GitHub Actions changelog-maintenance commits from appearing as contributor entries in generated release notes.

## Changes

- Normalize the workflow-generated commit scope to `chore(changelog)`.
- Make the git-cliff skip rule case-insensitive so it also covers historical `chore(Changelog)` commits.
- Remove the existing self-referential `github-actions` changelog entry and its dead profile link.

## Validation

- `actionlint .github/workflows/publish-changelog.yml`
- `markdownlint-cli2 --config .markdownlint.yaml '**/*.md'`
- `typos`
- `git diff --check`
- Lychee v0.24.2: 780 links checked, 0 errors
- [Stacked workflow run](https://github.com/MaaAssistantArknights/maa-cli/actions/runs/30258998093): Markdownlint, Dead Links, and Typos passed

## Stack

- Base PR: #565
- Retarget this PR to `main` after #565 is merged.