### PR TITLE
ci: add merge queue-compatible required checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Detect relevant paths
         if: github.event_name == 'pull_request' || github.event_name == 'push'
         id: filter
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@v4
         with:
           base: ${{ github.ref }}
           filters: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ on:
   pull_request:
     branches: ["main"]
   merge_group:
+    branches: ["main"]
     types: [checks_requested]
 
 env:
@@ -25,28 +26,27 @@ jobs:
     name: Detect code changes
     runs-on: ubuntu-latest
     outputs:
-      code: >-
-        ${{
-          (github.event_name != 'pull_request' && github.event_name != 'push') ||
-          steps.filter.outputs.code == 'true'
-        }}
+      code: ${{ steps.filter.outputs.code }}
     steps:
       - name: Checkout
-        if: github.event_name == 'push'
         uses: actions/checkout@v6
       - name: Detect relevant paths
-        if: github.event_name == 'pull_request' || github.event_name == 'push'
         id: filter
         uses: dorny/paths-filter@v4
         with:
-          base: ${{ github.ref }}
           filters: |
             code:
               - "crates/*/src/**"
+              - "crates/*/tests/**"
+              - "crates/*/fixtures/**"
+              - "crates/*/config_examples/**"
               - "crates/*/Cargo.toml"
               - "crates/*/build.rs"
               - "xtask/**"
+              - "Cargo.toml"
               - "Cargo.lock"
+              - "deny.toml"
+              - "rustfmt.toml"
               - "codecov.yml"
               - ".cargo/config.toml"
               - ".github/workflows/ci.yml"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,15 +3,6 @@ name: CI
 on:
   push:
     branches: ["main"]
-    paths:
-      - "crates/*/src/**"
-      - "crates/*/Cargo.toml"
-      - "crates/*/build.rs"
-      - "xtask/**"
-      - "Cargo.lock"
-      - "codecov.yml"
-      - ".cargo/config.toml"
-      - ".github/workflows/ci.yml"
   pull_request:
     branches: ["main"]
   merge_group:
@@ -34,13 +25,21 @@ jobs:
     name: Detect code changes
     runs-on: ubuntu-latest
     outputs:
-      code: ${{ github.event_name != 'pull_request' || steps.filter.outputs.code == 'true' }}
+      code: >-
+        ${{
+          (github.event_name != 'pull_request' && github.event_name != 'push') ||
+          steps.filter.outputs.code == 'true'
+        }}
     steps:
+      - name: Checkout
+        if: github.event_name == 'push'
+        uses: actions/checkout@v6
       - name: Detect relevant paths
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' || github.event_name == 'push'
         id: filter
         uses: dorny/paths-filter@v3
         with:
+          base: ${{ github.ref }}
           filters: |
             code:
               - "crates/*/src/**"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,15 +14,8 @@ on:
       - ".github/workflows/ci.yml"
   pull_request:
     branches: ["main"]
-    paths:
-      - "crates/*/src/**"
-      - "crates/*/Cargo.toml"
-      - "crates/*/build.rs"
-      - "xtask/**"
-      - "Cargo.lock"
-      - "codecov.yml"
-      - ".cargo/config.toml"
-      - ".github/workflows/ci.yml"
+  merge_group:
+    types: [checks_requested]
 
 env:
   RUST_BACKTRACE: full
@@ -30,14 +23,39 @@ env:
 
 permissions:
   contents: read
+  pull-requests: read
 
 defaults:
   run:
     shell: bash
 
 jobs:
+  changes:
+    name: Detect code changes
+    runs-on: ubuntu-latest
+    outputs:
+      code: ${{ github.event_name != 'pull_request' || steps.filter.outputs.code == 'true' }}
+    steps:
+      - name: Detect relevant paths
+        if: github.event_name == 'pull_request'
+        id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            code:
+              - "crates/*/src/**"
+              - "crates/*/Cargo.toml"
+              - "crates/*/build.rs"
+              - "xtask/**"
+              - "Cargo.lock"
+              - "codecov.yml"
+              - ".cargo/config.toml"
+              - ".github/workflows/ci.yml"
+
   typos:
     name: Lint (typos)
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -47,6 +65,8 @@ jobs:
 
   format:
     name: Lint (format)
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -58,6 +78,8 @@ jobs:
 
   deny:
     name: Lint (cargo deny)
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -71,6 +93,8 @@ jobs:
 
   build:
     name: Build and Test (${{ matrix.runner }})
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
@@ -90,6 +114,8 @@ jobs:
 
   build-windows:
     name: Build and Test (Windows, ${{ matrix.runner }})
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ${{ matrix.runner }}
     strategy:
       matrix:
@@ -105,7 +131,8 @@ jobs:
 
   build-tier2:
     name: Build and Test (Tier 2, ${{ matrix.runner }})
-    needs: [build]
+    needs: [changes, build]
+    if: needs.changes.outputs.code == 'true'
     runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
@@ -125,7 +152,8 @@ jobs:
 
   build-no-default-features:
     name: Build and Test (feature=${{ matrix.feature }})
-    needs: [build]
+    needs: [changes, build]
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
@@ -143,6 +171,8 @@ jobs:
 
   build-core:
     name: Build and Test (core binding, dynamic, ${{ matrix.os }})
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -171,7 +201,8 @@ jobs:
 
   coverage:
     name: Coverage
-    needs: [build]
+    needs: [changes, build]
+    if: needs.changes.outputs.code == 'true'
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -198,7 +229,8 @@ jobs:
 
   coverage-windows:
     name: Coverage (Windows)
-    needs: [build-windows]
+    needs: [changes, build-windows]
+    if: needs.changes.outputs.code == 'true'
     runs-on: windows-latest
     steps:
       - name: Checkout
@@ -215,3 +247,62 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: codecov.json
           fail_ci_if_error: true
+
+  required:
+    name: CI Required
+    if: always()
+    needs:
+      - changes
+      - typos
+      - format
+      - deny
+      - build
+      - build-windows
+      - build-tier2
+      - build-no-default-features
+      - build-core
+      - coverage
+      - coverage-windows
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify required jobs
+        env:
+          CODE_CHANGED: ${{ needs.changes.outputs.code }}
+          CHANGES_RESULT: ${{ needs.changes.result }}
+          TYPOS_RESULT: ${{ needs.typos.result }}
+          FORMAT_RESULT: ${{ needs.format.result }}
+          DENY_RESULT: ${{ needs.deny.result }}
+          BUILD_RESULT: ${{ needs.build.result }}
+          BUILD_WINDOWS_RESULT: ${{ needs.build-windows.result }}
+          BUILD_TIER2_RESULT: ${{ needs.build-tier2.result }}
+          BUILD_FEATURES_RESULT: ${{ needs.build-no-default-features.result }}
+          BUILD_CORE_RESULT: ${{ needs.build-core.result }}
+          COVERAGE_RESULT: ${{ needs.coverage.result }}
+          COVERAGE_WINDOWS_RESULT: ${{ needs.coverage-windows.result }}
+        run: |
+          if [[ "$CHANGES_RESULT" != "success" ]]; then
+            echo "Change detection failed"
+            exit 1
+          fi
+
+          if [[ "$CODE_CHANGED" != "true" ]]; then
+            echo "No code changes require CI"
+            exit 0
+          fi
+
+          for result in \
+            "$TYPOS_RESULT" \
+            "$FORMAT_RESULT" \
+            "$DENY_RESULT" \
+            "$BUILD_RESULT" \
+            "$BUILD_WINDOWS_RESULT" \
+            "$BUILD_TIER2_RESULT" \
+            "$BUILD_FEATURES_RESULT" \
+            "$BUILD_CORE_RESULT" \
+            "$COVERAGE_RESULT" \
+            "$COVERAGE_WINDOWS_RESULT"; do
+            if [[ "$result" != "success" ]]; then
+              echo "A required CI job did not succeed: $result"
+              exit 1
+            fi
+          done

--- a/.github/workflows/lint-docs.yml
+++ b/.github/workflows/lint-docs.yml
@@ -5,22 +5,40 @@ on:
     branches: ["main"]
     paths:
       - "**/*.md"
-      - ".github/workflows/lint-markdown.yml"
+      - ".github/workflows/lint-docs.yml"
   pull_request:
     branches: ["main"]
-    paths:
-      - "**/*.md"
-      - ".github/workflows/lint-markdown.yml"
+  merge_group:
+    types: [checks_requested]
   schedule:
     - cron: "44 7 * * 2"
   workflow_dispatch:
 
 permissions:
   contents: read
+  pull-requests: read
 
 jobs:
+  changes:
+    name: Detect documentation changes
+    runs-on: ubuntu-latest
+    outputs:
+      docs: ${{ github.event_name != 'pull_request' || steps.filter.outputs.docs == 'true' }}
+    steps:
+      - name: Detect relevant paths
+        if: github.event_name == 'pull_request'
+        id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            docs:
+              - "**/*.md"
+              - ".github/workflows/lint-docs.yml"
+
   typos:
     name: Typos
+    needs: changes
+    if: needs.changes.outputs.docs == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -30,6 +48,8 @@ jobs:
 
   markdownlint:
     name: Markdownlint
+    needs: changes
+    if: needs.changes.outputs.docs == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -42,8 +62,11 @@ jobs:
 
   deadlinks:
     name: Dead Links
+    needs: changes
+    if: needs.changes.outputs.docs == 'true'
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       pull-requests: write
     steps:
       - name: Checkout
@@ -67,3 +90,41 @@ jobs:
           message: |
             Dead links found in the documentation. Please fix them.
             Details: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
+  required:
+    name: Docs Required
+    if: always()
+    needs:
+      - changes
+      - typos
+      - markdownlint
+      - deadlinks
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify required jobs
+        env:
+          DOCS_CHANGED: ${{ needs.changes.outputs.docs }}
+          CHANGES_RESULT: ${{ needs.changes.result }}
+          TYPOS_RESULT: ${{ needs.typos.result }}
+          MARKDOWNLINT_RESULT: ${{ needs.markdownlint.result }}
+          DEADLINKS_RESULT: ${{ needs.deadlinks.result }}
+        run: |
+          if [[ "$CHANGES_RESULT" != "success" ]]; then
+            echo "Change detection failed"
+            exit 1
+          fi
+
+          if [[ "$DOCS_CHANGED" != "true" ]]; then
+            echo "No documentation changes require linting"
+            exit 0
+          fi
+
+          for result in \
+            "$TYPOS_RESULT" \
+            "$MARKDOWNLINT_RESULT" \
+            "$DEADLINKS_RESULT"; do
+            if [[ "$result" != "success" ]]; then
+              echo "A required documentation job did not succeed: $result"
+              exit 1
+            fi
+          done

--- a/.github/workflows/lint-docs.yml
+++ b/.github/workflows/lint-docs.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Detect relevant paths
         if: github.event_name == 'pull_request' || github.event_name == 'push'
         id: filter
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@v4
         with:
           base: ${{ github.ref }}
           filters: |

--- a/.github/workflows/lint-docs.yml
+++ b/.github/workflows/lint-docs.yml
@@ -6,6 +6,7 @@ on:
   pull_request:
     branches: ["main"]
   merge_group:
+    branches: ["main"]
     types: [checks_requested]
   schedule:
     - cron: "44 7 * * 2"
@@ -20,25 +21,42 @@ jobs:
     name: Detect documentation changes
     runs-on: ubuntu-latest
     outputs:
-      docs: >-
-        ${{
-          (github.event_name != 'pull_request' && github.event_name != 'push') ||
-          steps.filter.outputs.docs == 'true'
-        }}
+      docs: ${{ steps.resolve.outputs.docs }}
     steps:
       - name: Checkout
-        if: github.event_name == 'push'
         uses: actions/checkout@v6
       - name: Detect relevant paths
-        if: github.event_name == 'pull_request' || github.event_name == 'push'
+        if: >-
+          github.event_name == 'pull_request' ||
+          github.event_name == 'push' ||
+          github.event_name == 'merge_group'
         id: filter
         uses: dorny/paths-filter@v4
         with:
-          base: ${{ github.ref }}
           filters: |
             docs:
               - "**/*.md"
+              - ".markdownlint.yaml"
               - ".github/workflows/lint-docs.yml"
+      - name: Resolve documentation changes
+        id: resolve
+        env:
+          FILTER_RESULT: ${{ steps.filter.outputs.docs }}
+        run: |
+          case "$GITHUB_EVENT_NAME" in
+            pull_request | push | merge_group)
+              if [[ "$FILTER_RESULT" != "true" && "$FILTER_RESULT" != "false" ]]; then
+                echo "Invalid documentation filter result: $FILTER_RESULT"
+                exit 1
+              fi
+              docs="$FILTER_RESULT"
+              ;;
+            *)
+              docs=true
+              ;;
+          esac
+
+          echo "docs=$docs" >> "$GITHUB_OUTPUT"
 
   typos:
     name: Typos

--- a/.github/workflows/lint-docs.yml
+++ b/.github/workflows/lint-docs.yml
@@ -3,9 +3,6 @@ name: Lint Markdown files
 on:
   push:
     branches: ["main"]
-    paths:
-      - "**/*.md"
-      - ".github/workflows/lint-docs.yml"
   pull_request:
     branches: ["main"]
   merge_group:
@@ -23,13 +20,21 @@ jobs:
     name: Detect documentation changes
     runs-on: ubuntu-latest
     outputs:
-      docs: ${{ github.event_name != 'pull_request' || steps.filter.outputs.docs == 'true' }}
+      docs: >-
+        ${{
+          (github.event_name != 'pull_request' && github.event_name != 'push') ||
+          steps.filter.outputs.docs == 'true'
+        }}
     steps:
+      - name: Checkout
+        if: github.event_name == 'push'
+        uses: actions/checkout@v6
       - name: Detect relevant paths
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' || github.event_name == 'push'
         id: filter
         uses: dorny/paths-filter@v3
         with:
+          base: ${{ github.ref }}
           filters: |
             docs:
               - "**/*.md"


### PR DESCRIPTION
## Summary

Prepare the CI and documentation workflows for GitHub merge queues by adding `merge_group` support and stable required-check gates, while continuing to skip expensive jobs when the relevant files did not change.

## Changes

- trigger both workflows for `merge_group` `checks_requested` events targeting `main`
- replace duplicated event-level path filters with shared `dorny/paths-filter@v4` change-detection jobs for pull requests, pushes, and merge groups
- include Rust sources, tests, fixtures, configuration examples, workspace manifests, lint configuration, and workflow files in the code filter
- include Markdown files, Markdownlint configuration, and the documentation workflow itself in the documentation filter
- gate expensive jobs on the detected change set and expose stable `CI Required` and `Docs Required` aggregate checks for branch protection
- keep scheduled and manually dispatched documentation runs unconditional so dead-link checks still run across all documentation

This PR only prepares the workflows. The repository merge queue and required-check settings should be enabled after these gate jobs have run successfully on `main`.

## Validation

- `actionlint .github/workflows/ci.yml .github/workflows/lint-docs.yml`
- `git diff --check`
- `cargo +nightly fmt`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo x test --no-core-tests`
- independent working-tree patch review