### PR TITLE
feat: support new PRTS copilot URI format

### DIFF
--- a/crates/maa-cli/src/run/preset/copilot.rs
+++ b/crates/maa-cli/src/run/preset/copilot.rs
@@ -386,12 +386,11 @@ impl CopilotFile {
 
         if let Some(code) = trimmed.strip_prefix("prts://") {
             if let Some(code) = code.strip_prefix('s') {
-                return Ok(Self::RemoteSet(parse_code(code)?));
+                Ok(Self::RemoteSet(parse_code(code)?))
+            } else {
+                Ok(Self::Remote(parse_code(code)?))
             }
-            return Ok(Self::Remote(parse_code(code)?));
-        }
-
-        if let Some(code) = trimmed.strip_prefix("maa://") {
+        } else if let Some(code) = trimmed.strip_prefix("maa://") {
             LEGACY_URI_WARNING.call_once(|| {
                 warn!(
                     "The maa:// URI format is deprecated; use prts://<id> or prts://s<id> instead"
@@ -399,13 +398,15 @@ impl CopilotFile {
             });
 
             if let Some(code) = code.strip_suffix('s') {
-                return Ok(Self::RemoteSet(parse_code(code)?));
+                Ok(Self::RemoteSet(parse_code(code)?))
+            } else {
+                Ok(Self::Remote(parse_code(code)?))
             }
-            return Ok(Self::Remote(parse_code(code)?));
+        } else if let Some(path) = trimmed.strip_prefix("file://") {
+            Ok(Self::Local(PathBuf::from(path)))
+        } else {
+            Ok(Self::Local(PathBuf::from(trimmed)))
         }
-
-        let path = trimmed.strip_prefix("file://").unwrap_or(trimmed);
-        Ok(Self::Local(PathBuf::from(path)))
     }
 
     pub fn push_path_into<T>(

--- a/crates/maa-cli/src/run/preset/copilot.rs
+++ b/crates/maa-cli/src/run/preset/copilot.rs
@@ -1,6 +1,7 @@
 use std::{
     fs,
     path::{Path, PathBuf},
+    sync::Once,
 };
 
 use anyhow::{Context, Result, bail};
@@ -26,6 +27,8 @@ const COPILOT_SET_API: &str = "https://prts.maa.plus/set/get?id=";
 const COPILOT_API: &str = "http://127.0.0.1:18080/copilot/get/";
 #[cfg(test)]
 const COPILOT_SET_API: &str = "http://127.0.0.1:18080/set/get?id=";
+
+static LEGACY_URI_WARNING: Once = Once::new();
 
 /// Raid mode for copilot stages.
 #[cfg_attr(test, derive(Debug, PartialEq, Eq))]
@@ -374,37 +377,36 @@ enum CopilotFile {
 }
 
 impl CopilotFile {
+    fn parse_code(code: &str) -> Result<u64> {
+        code.parse::<u64>().context("Invalid code")
+    }
+
     fn from_uri(uri: &str) -> Result<Self> {
         let trimmed = uri.trim();
-        let remote = if let Some(code_str) = trimmed.strip_prefix("prts://") {
-            if let Some(code_str) = code_str.strip_prefix('s') {
-                Some((code_str, true))
-            } else {
-                Some((code_str, false))
-            }
-        } else if let Some(code_str) = trimmed.strip_prefix("maa://") {
-            warn!("The maa:// URI format is deprecated; use prts://<id> or prts://s<id> instead");
-            if let Some(code_str) = code_str.strip_suffix('s') {
-                Some((code_str, true))
-            } else {
-                Some((code_str, false))
-            }
-        } else {
-            None
-        };
 
-        if let Some((code_str, is_set)) = remote {
-            let code = code_str.parse::<u64>().context("Invalid code")?;
-            if is_set {
-                Ok(CopilotFile::RemoteSet(code))
-            } else {
-                Ok(CopilotFile::Remote(code))
-            }
-        } else if let Some(code) = trimmed.strip_prefix("file://") {
-            Ok(CopilotFile::Local(PathBuf::from(code)))
-        } else {
-            Ok(CopilotFile::Local(PathBuf::from(trimmed)))
+        if let Some(code) = trimmed.strip_prefix("prts://s") {
+            return Ok(Self::RemoteSet(Self::parse_code(code)?));
         }
+
+        if let Some(code) = trimmed.strip_prefix("prts://") {
+            return Ok(Self::Remote(Self::parse_code(code)?));
+        }
+
+        if let Some(code) = trimmed.strip_prefix("maa://") {
+            LEGACY_URI_WARNING.call_once(|| {
+                warn!(
+                    "The maa:// URI format is deprecated; use prts://<id> or prts://s<id> instead"
+                );
+            });
+
+            if let Some(code) = code.strip_suffix('s') {
+                return Ok(Self::RemoteSet(Self::parse_code(code)?));
+            }
+            return Ok(Self::Remote(Self::parse_code(code)?));
+        }
+
+        let path = trimmed.strip_prefix("file://").unwrap_or(trimmed);
+        Ok(Self::Local(PathBuf::from(path)))
     }
 
     pub fn push_path_into<T>(
@@ -1500,6 +1502,7 @@ found"}"#,
             fn invalid_code() {
                 assert!(CopilotFile::from_uri("prts://xyz").is_err());
                 assert!(CopilotFile::from_uri("prts://s").is_err());
+                assert!(CopilotFile::from_uri("maa://xyz").is_err());
             }
 
             #[test]

--- a/crates/maa-cli/src/run/preset/copilot.rs
+++ b/crates/maa-cli/src/run/preset/copilot.rs
@@ -377,19 +377,18 @@ enum CopilotFile {
 }
 
 impl CopilotFile {
-    fn parse_code(code: &str) -> Result<u64> {
-        code.parse::<u64>().context("Invalid code")
-    }
-
     fn from_uri(uri: &str) -> Result<Self> {
-        let trimmed = uri.trim();
-
-        if let Some(code) = trimmed.strip_prefix("prts://s") {
-            return Ok(Self::RemoteSet(Self::parse_code(code)?));
+        fn parse_code(code: &str) -> Result<u64> {
+            code.parse::<u64>().context("Invalid code")
         }
 
+        let trimmed = uri.trim();
+
         if let Some(code) = trimmed.strip_prefix("prts://") {
-            return Ok(Self::Remote(Self::parse_code(code)?));
+            if let Some(code) = code.strip_prefix('s') {
+                return Ok(Self::RemoteSet(parse_code(code)?));
+            }
+            return Ok(Self::Remote(parse_code(code)?));
         }
 
         if let Some(code) = trimmed.strip_prefix("maa://") {
@@ -400,9 +399,9 @@ impl CopilotFile {
             });
 
             if let Some(code) = code.strip_suffix('s') {
-                return Ok(Self::RemoteSet(Self::parse_code(code)?));
+                return Ok(Self::RemoteSet(parse_code(code)?));
             }
-            return Ok(Self::Remote(Self::parse_code(code)?));
+            return Ok(Self::Remote(parse_code(code)?));
         }
 
         let path = trimmed.strip_prefix("file://").unwrap_or(trimmed);

--- a/crates/maa-cli/src/run/preset/copilot.rs
+++ b/crates/maa-cli/src/run/preset/copilot.rs
@@ -376,15 +376,29 @@ enum CopilotFile {
 impl CopilotFile {
     fn from_uri(uri: &str) -> Result<Self> {
         let trimmed = uri.trim();
-        if let Some(code_str) = trimmed.strip_prefix("maa://") {
-            if let Some(code_str) = code_str.strip_suffix('s') {
-                Ok(CopilotFile::RemoteSet(
-                    code_str.parse::<u64>().context("Invalid code")?,
-                ))
+        let remote = if let Some(code_str) = trimmed.strip_prefix("prts://") {
+            if let Some(code_str) = code_str.strip_prefix('s') {
+                Some((code_str, true))
             } else {
-                Ok(CopilotFile::Remote(
-                    code_str.parse::<u64>().context("Invalid code")?,
-                ))
+                Some((code_str, false))
+            }
+        } else if let Some(code_str) = trimmed.strip_prefix("maa://") {
+            warn!("The maa:// URI format is deprecated; use prts://<id> or prts://s<id> instead");
+            if let Some(code_str) = code_str.strip_suffix('s') {
+                Some((code_str, true))
+            } else {
+                Some((code_str, false))
+            }
+        } else {
+            None
+        };
+
+        if let Some((code_str, is_set)) = remote {
+            let code = code_str.parse::<u64>().context("Invalid code")?;
+            if is_set {
+                Ok(CopilotFile::RemoteSet(code))
+            } else {
+                Ok(CopilotFile::Remote(code))
             }
         } else if let Some(code) = trimmed.strip_prefix("file://") {
             Ok(CopilotFile::Local(PathBuf::from(code)))
@@ -1484,13 +1498,14 @@ found"}"#,
 
             #[test]
             fn invalid_code() {
-                assert!(CopilotFile::from_uri("maa://xyz").is_err());
+                assert!(CopilotFile::from_uri("prts://xyz").is_err());
+                assert!(CopilotFile::from_uri("prts://s").is_err());
             }
 
             #[test]
             fn remote_set() {
                 assert_eq!(
-                    CopilotFile::from_uri("maa://20001s").unwrap(),
+                    CopilotFile::from_uri("prts://s20001").unwrap(),
                     CopilotFile::RemoteSet(20001)
                 );
             }
@@ -1498,8 +1513,20 @@ found"}"#,
             #[test]
             fn remote() {
                 assert_eq!(
+                    CopilotFile::from_uri("prts://30001").unwrap(),
+                    CopilotFile::Remote(30001)
+                );
+            }
+
+            #[test]
+            fn legacy_remote_remains_supported() {
+                assert_eq!(
                     CopilotFile::from_uri("maa://30001").unwrap(),
                     CopilotFile::Remote(30001)
+                );
+                assert_eq!(
+                    CopilotFile::from_uri("maa://20001s").unwrap(),
+                    CopilotFile::RemoteSet(20001)
                 );
             }
 
@@ -1522,7 +1549,7 @@ found"}"#,
             #[test]
             fn with_whitespace() {
                 assert_eq!(
-                    CopilotFile::from_uri("  maa://30001  ").unwrap(),
+                    CopilotFile::from_uri("  prts://30001  ").unwrap(),
                     CopilotFile::Remote(30001)
                 );
 


### PR DESCRIPTION
## Summary

Support the new PRTS.plus copilot URI format while keeping legacy codes usable during migration.

## Changes

- parse `prts://<id>` as a single copilot task
- parse `prts://s<id>` as a copilot task set
- continue parsing legacy `maa://` codes with a deprecation warning
- cover new, legacy, invalid, and whitespace parser inputs

## Validation

- `cargo +nightly fmt`
- `cargo clippy`
- `cargo test -p maa-cli` (308 passed, 26 ignored)
- `cargo x test --no-core-tests`

## Summary by Sourcery

在保持对旧版 MA URI 代码的迁移路径的同时，支持新的 PRTS copilot URI 格式。

新功能：
- 支持解析 `prts://<id>` copilot 任务 URI 和 `prts://s<id>` copilot 任务集 URI。

改进：
- 在继续支持旧版 `maa://` copilot URI 的同时，输出一次性弃用警告。
- 在保留本地路径解析的前提下，一致地规范化周围的空白字符。

测试：
- 扩展 URI 解析覆盖范围，包括新的、旧的、无效的以及带空白填充的输入。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Support the new PRTS copilot URI formats while maintaining a migration path for legacy MA URI codes.

New Features:
- Support parsing `prts://<id>` copilot task URIs and `prts://s<id>` copilot task-set URIs.

Enhancements:
- Preserve support for legacy `maa://` copilot URIs while emitting a one-time deprecation warning.
- Normalize surrounding whitespace consistently while retaining local path parsing.

Tests:
- Expand URI parsing coverage for new, legacy, invalid, and whitespace-padded inputs.

</details>

新功能：
- 支持解析 `prts://<id>` 助理任务 URI 和 `prts://s<id>` 助理任务集 URI。

改进：
- 保持传统 `maa://` 助理 URI 可用，同时发出一次性的弃用警告。
- 一致地处理 URI 中的空白字符，并保留本地路径解析逻辑。

测试：
- 扩展对新格式、传统格式、无效格式以及带空白填充输入的助理 URI 解析覆盖范围。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在保持对旧版 MA URI 代码的迁移路径的同时，支持新的 PRTS copilot URI 格式。

新功能：
- 支持解析 `prts://<id>` copilot 任务 URI 和 `prts://s<id>` copilot 任务集 URI。

改进：
- 在继续支持旧版 `maa://` copilot URI 的同时，输出一次性弃用警告。
- 在保留本地路径解析的前提下，一致地规范化周围的空白字符。

测试：
- 扩展 URI 解析覆盖范围，包括新的、旧的、无效的以及带空白填充的输入。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Support the new PRTS copilot URI formats while maintaining a migration path for legacy MA URI codes.

New Features:
- Support parsing `prts://<id>` copilot task URIs and `prts://s<id>` copilot task-set URIs.

Enhancements:
- Preserve support for legacy `maa://` copilot URIs while emitting a one-time deprecation warning.
- Normalize surrounding whitespace consistently while retaining local path parsing.

Tests:
- Expand URI parsing coverage for new, legacy, invalid, and whitespace-padded inputs.

</details>

</details>

新功能：
- 增加对解析 `prts://<id>` 和 `prts://s<id>` URI 的支持，将其转换为远程 copilot 任务和任务集。

改进：
- 统一远程 copilot URI 解析逻辑，并在使用旧版 `maa://` URI 时输出弃用警告。

测试：
- 扩展 copilot URI 解析测试，以覆盖新的 `prts://` 格式、旧版 `maa://` 格式、无效输入以及空白字符处理。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在保持对旧版 MA URI 代码的迁移路径的同时，支持新的 PRTS copilot URI 格式。

新功能：
- 支持解析 `prts://<id>` copilot 任务 URI 和 `prts://s<id>` copilot 任务集 URI。

改进：
- 在继续支持旧版 `maa://` copilot URI 的同时，输出一次性弃用警告。
- 在保留本地路径解析的前提下，一致地规范化周围的空白字符。

测试：
- 扩展 URI 解析覆盖范围，包括新的、旧的、无效的以及带空白填充的输入。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Support the new PRTS copilot URI formats while maintaining a migration path for legacy MA URI codes.

New Features:
- Support parsing `prts://<id>` copilot task URIs and `prts://s<id>` copilot task-set URIs.

Enhancements:
- Preserve support for legacy `maa://` copilot URIs while emitting a one-time deprecation warning.
- Normalize surrounding whitespace consistently while retaining local path parsing.

Tests:
- Expand URI parsing coverage for new, legacy, invalid, and whitespace-padded inputs.

</details>

新功能：
- 支持解析 `prts://<id>` 助理任务 URI 和 `prts://s<id>` 助理任务集 URI。

改进：
- 保持传统 `maa://` 助理 URI 可用，同时发出一次性的弃用警告。
- 一致地处理 URI 中的空白字符，并保留本地路径解析逻辑。

测试：
- 扩展对新格式、传统格式、无效格式以及带空白填充输入的助理 URI 解析覆盖范围。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在保持对旧版 MA URI 代码的迁移路径的同时，支持新的 PRTS copilot URI 格式。

新功能：
- 支持解析 `prts://<id>` copilot 任务 URI 和 `prts://s<id>` copilot 任务集 URI。

改进：
- 在继续支持旧版 `maa://` copilot URI 的同时，输出一次性弃用警告。
- 在保留本地路径解析的前提下，一致地规范化周围的空白字符。

测试：
- 扩展 URI 解析覆盖范围，包括新的、旧的、无效的以及带空白填充的输入。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Support the new PRTS copilot URI formats while maintaining a migration path for legacy MA URI codes.

New Features:
- Support parsing `prts://<id>` copilot task URIs and `prts://s<id>` copilot task-set URIs.

Enhancements:
- Preserve support for legacy `maa://` copilot URIs while emitting a one-time deprecation warning.
- Normalize surrounding whitespace consistently while retaining local path parsing.

Tests:
- Expand URI parsing coverage for new, legacy, invalid, and whitespace-padded inputs.

</details>

</details>

</details>

Closes #577