### PR TITLE
docs(config): add end-to-end PlayCover (macOS) example

### DIFF
--- a/crates/maa-cli/docs/en-US/config.md
+++ b/crates/maa-cli/docs/en-US/config.md
@@ -345,8 +345,39 @@ There are two special presets: `PlayCover` (macOS) and `Waydroid` (Linux)
 
 - `PlayCover` is for connecting to iOS apps running natively on macOS through PlayCover.
 
-   In this case, `adb_path` is ignored and `address` is the address of `PlayTools`.
-   See [PlayCover documentation][playcover-doc] for details.
+   In this case, `adb_path` is ignored and `address` is the address of `PlayTools`
+   (the MaaTools port configured in PlayCover, `localhost:1717` by default):
+
+   ```toml
+   [connection]
+   preset = "PlayCover"
+   address = "localhost:1717"
+   ```
+
+   > **Prerequisite:** the game must already be running under PlayCover with MaaTools
+   > enabled and listening (default port `1717`) before maa-cli connects; otherwise the
+   > connection falls back to ADB and fails. maa-cli can also launch the app for you when
+   > a `StartUp` task sets `start_game_enabled = true`.
+
+   A complete task file (`$MAA_CONFIG_DIR/tasks/daily.toml`) that starts the game, runs
+   the Sami roguelike, then closes it looks like:
+
+   ```toml
+   [[tasks]]
+   type = "StartUp"
+   params = { client_type = "Official", start_game_enabled = true }
+
+   [[tasks]]
+   type = "Roguelike"
+   params = { theme = "Sami", mode = 0, squad = "指挥分队", investment_enabled = true }
+
+   [[tasks]]
+   type = "CloseDown"
+   params = { client_type = "Official" }
+   ```
+
+   Run it with `maa run daily`. See [PlayCover documentation][playcover-doc] for
+   installing the client and enabling MaaTools.
 
 - `Waydroid` is for connecting to Android apps running natively on Linux through Waydroid.
 

--- a/crates/maa-cli/docs/zh-CN/config.md
+++ b/crates/maa-cli/docs/zh-CN/config.md
@@ -332,7 +332,33 @@ address = "127.0.0.1:7777" # 如果你需要的话，你可以覆盖预设的地
 
 目前预配置了两种预设，为 `PlayCover` (MacOS), `Waydroid` (Linux)
 
-- `PlayCover`用于在 macOS 上连接直接通过 `PlayCover` 原生运行的游戏客户端。这种情况下不需要指定 `adb_path` 且 `address` 不是 `adb` 连接的地址而是 `PlayTools` 的地址，具体使用参见 [PlayCover 支持文档][playcover-doc].
+- `PlayCover` 用于在 macOS 上连接直接通过 `PlayCover` 原生运行的游戏客户端。这种情况下不需要指定 `adb_path`，`address` 不是 `adb` 连接的地址，而是 `PlayTools` 的地址（在 PlayCover 中配置的 MaaTools 端口，默认 `localhost:1717`）：
+
+  ```toml
+  [connection]
+  preset = "PlayCover"
+  address = "localhost:1717"
+  ```
+
+  > **前置条件**：在 maa-cli 连接之前，游戏必须已在 PlayCover 中运行并启用 MaaTools 监听端口（默认 `1717`），否则连接会回退到 ADB 并失败。若 `StartUp` 任务设置了 `start_game_enabled = true`，maa-cli 也可以替你启动游戏。
+
+  一个完整的任务文件（`$MAA_CONFIG_DIR/tasks/daily.toml`）——启动游戏、跑萨米肉鸽、再关闭：
+
+  ```toml
+  [[tasks]]
+  type = "StartUp"
+  params = { client_type = "Official", start_game_enabled = true }
+
+  [[tasks]]
+  type = "Roguelike"
+  params = { theme = "Sami", mode = 0, squad = "指挥分队", investment_enabled = true }
+
+  [[tasks]]
+  type = "CloseDown"
+  params = { client_type = "Official" }
+  ```
+
+  用 `maa run daily` 运行。安装客户端与启用 MaaTools 的方法参见 [PlayCover 支持文档][playcover-doc]。
 
 - `Waydroid`用于在 Linux 上连接直接通过 `Waydroid` 原生运行的游戏客户端。这种情况下仍需要指定 `adb_path` 供 MaaCore 连接设备使用。maa-cli 会自动管理会话：通过 `waydroid status` 检测会话是否已在运行，必要时启动会话，然后通过 `waydroid adb connect` 建立 ADB 连接。
   具体使用参见 [Waydroid 支持文档][waydroid-doc].


### PR DESCRIPTION
## What

The `[connection]` docs mention the `PlayCover` special preset but never show:

- the PlayTools **address** (`localhost:1717`),
- the **prerequisite** that the game / MaaTools must already be running before maa-cli connects, and
- a full **task-chain example** wiring the connection to actual tasks.

New macOS users therefore hit `Unknown connection preset` (from copying the rendered label `PlayCover (macOS)` verbatim) or ADB-fallback connection failures, with nothing runnable to copy.

## Change

Expand the `PlayCover` special-preset entry in both `en-US/config.md` and `zh-CN/config.md` with:

1. A copy-pasteable `[connection]` block (`preset = "PlayCover"`, `address = "localhost:1717"`).
2. A prerequisite note (game + MaaTools listening on `1717` first; `StartUp` can launch it).
3. A complete `StartUp -> Roguelike -> CloseDown` task file plus `maa run daily`.

Docs-only. `markdownlint-cli2 --config .markdownlint.yaml` passes on both files.

## Summary by Sourcery

在 maa-cli 配置文档中补充有关 PlayCover（macOS）连接用法的说明，并提供一个可直接复制粘贴的完整示例工作流。

Documentation:
- 在英文配置文档中添加明确的 PlayCover 预设连接示例，包含 PlayTools 默认地址及前置条件说明。
- 在中文配置文档中添加本地化的 PlayCover 预设连接与任务链示例，包括启动、肉鸽（roguelike）以及关闭任务。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Document PlayCover (macOS) connection usage in maa-cli configuration docs with a complete, copy-pasteable example workflow.

Documentation:
- Add explicit PlayCover preset connection example with PlayTools default address and prerequisite notes to the English config documentation.
- Add a localized PlayCover preset connection and task-chain example, including startup, roguelike, and shutdown tasks, to the Chinese config documentation.

</details>