### PR TITLE
feat(config): add Window connection preset for X11 window control

### DIFF
--- a/crates/maa-cli/src/config/asst.rs
+++ b/crates/maa-cli/src/config/asst.rs
@@ -86,11 +86,27 @@ pub struct ConnectionConfig {
     pub(super) address: Option<String>,
     #[serde(default)]
     pub(super) config: Option<String>,
+    /// Target X11 window title for the `Window` preset (e.g. "Arknights").
+    #[serde(default)]
+    pub(super) window_name: Option<String>,
+    /// Whether to move input focus to the game window before sending keys.
+    #[serde(default)]
+    pub(super) focus_for_keys: Option<bool>,
 }
 
 impl ConnectionConfig {
     pub fn preset(&self) -> Preset {
         self.preset
+    }
+
+    /// Window title used by the `Window` preset; defaults to "Arknights".
+    pub fn window_name(&self) -> &str {
+        self.window_name.as_deref().unwrap_or("Arknights")
+    }
+
+    /// Whether to focus the target window before sending keys.
+    pub fn focus_for_keys(&self) -> bool {
+        self.focus_for_keys.unwrap_or(false)
     }
 
     pub fn set_address(&mut self, address: impl Into<String>) -> &mut Self {
@@ -146,6 +162,9 @@ pub enum Preset {
     PlayCover,
     Waydroid,
     Androws,
+    /// Bind to an X11 window by title (Linux).
+    #[cfg(not(target_os = "windows"))]
+    Window,
     #[default]
     Adb,
 }
@@ -174,6 +193,8 @@ impl<'de> Deserialize<'de> for Preset {
                     "ADB" | "Adb" | "adb" => Ok(Preset::Adb),
                     "Waydroid" | "waydroid" => Ok(Preset::Waydroid),
                     "Androws" | "androws" => Ok(Preset::Androws),
+                    #[cfg(not(target_os = "windows"))]
+                    "Window" | "window" => Ok(Preset::Window),
                     _ => {
                         warn!("Unknown connection preset: {value}, ignoring");
                         Ok(Preset::Adb)
@@ -194,6 +215,8 @@ impl Preset {
             ),
             Preset::PlayCover => Cow::Borrowed(""),
             Preset::Waydroid | Preset::Adb => Cow::Borrowed("adb"),
+            #[cfg(not(target_os = "windows"))]
+            Preset::Window => Cow::Borrowed(""),
             Preset::Androws => {
                 #[cfg(windows)]
                 if let Some(path) = get_androws_adb_path() {
@@ -210,6 +233,8 @@ impl Preset {
             Preset::PlayCover => "127.0.0.1:1717".into(),
             Preset::Androws => "127.0.0.1:5555".into(),
             Preset::Waydroid => "waydroid".into(),
+            #[cfg(not(target_os = "windows"))]
+            Preset::Window => "".into(),
             Preset::Adb => std::process::Command::new(adb_path)
                 .arg("devices")
                 .output()
@@ -230,6 +255,8 @@ impl Preset {
             Preset::Androws => "Androws",
             // May be preset specific in the future
             Preset::MuMuPro | Preset::PlayCover | Preset::Adb => config_based_on_os(),
+            #[cfg(not(target_os = "windows"))]
+            Preset::Window => "General",
         }
     }
 }

--- a/crates/maa-cli/src/run/mod.rs
+++ b/crates/maa-cli/src/run/mod.rs
@@ -217,8 +217,20 @@ where
 
         let address = runtime_address.as_deref().unwrap_or(&address);
 
-        // Connect to game or emulator
-        asst.async_connect(adb_path.as_ref(), address, config, true)?;
+        // Connect to game or emulator / bind to an X11 window
+        match asst_config.connection.preset() {
+            #[cfg(not(target_os = "windows"))]
+            crate::config::asst::Preset::Window => {
+                asst.async_attach_window_by_name(
+                    asst_config.connection.window_name(),
+                    asst_config.connection.focus_for_keys(),
+                    true,
+                )?;
+            }
+            _ => {
+                asst.async_connect(adb_path.as_ref(), address, config, true)?;
+            }
+        }
 
         debug!("Starting MAA...");
         asst.start()?;

--- a/crates/maa-core/src/lib.rs
+++ b/crates/maa-core/src/lib.rs
@@ -232,6 +232,26 @@ impl Assistant {
         .to_maa_result()
     }
 
+    /// Bind to an X11 window by its title (Linux), asynchronously.
+    #[cfg(not(target_os = "windows"))]
+    pub fn async_attach_window_by_name(
+        &self,
+        window_name: impl ToCString,
+        focus_for_keys: bool,
+        block: bool,
+    ) -> Result<AsstAsyncCallId> {
+        let window_name = window_name.to_cstring()?;
+        unsafe {
+            maa_sys::binding::AsstAsyncAttachWindowByName(
+                self.handle,
+                window_name.as_ptr(),
+                focus_for_keys.into(),
+                block.into(),
+            )
+        }
+        .to_maa_result()
+    }
+
     /// Click the screen at the given position.
     pub fn async_click(&self, x: i32, y: i32, block: bool) -> Result<AsstAsyncCallId> {
         unsafe { maa_sys::binding::AsstAsyncClick(self.handle, x, y, block.into()) }.to_maa_result()

--- a/crates/maa-sys/src/binding.rs
+++ b/crates/maa-sys/src/binding.rs
@@ -52,6 +52,14 @@ link! {
     ) -> AsstAsyncCallId;
     pub fn AsstSetConnectionExtras(name: *const c_char, extras: *const c_char);
 
+    #[cfg(not(target_os = "windows"))]
+    pub fn AsstAsyncAttachWindowByName(
+        handle: AsstHandle,
+        window_name: *const c_char,
+        focus_for_keys: AsstBool,
+        block: AsstBool,
+    ) -> AsstAsyncCallId;
+
     #[cfg(target_os = "windows")]
     pub fn AsstAsyncAttachWindow(
         handle: AsstHandle,


### PR DESCRIPTION
## Summary

Adds a `Window` connection preset that binds to an X11 window by title via the new `AsstAsyncAttachWindowByName` API, for controlling e.g. the Arknights PC client running under Wine/Proton on Linux. Input is delivered via synthetic X11 events (`XSendEvent`): **the cursor is not moved and focus is not stolen** — the desktop stays usable while MAA runs.

Companion change: [MaaAssistantArknights/MaaAssistantArknights#17713](https://github.com/MaaAssistantArknights/MaaAssistantArknights/pull/17713) (the `LinuxWindowController` in MaaCore, built with `ASST_WITH_X11`).

## Changes

- `maa-sys`: bind `AsstAsyncAttachWindowByName` (non-Windows)
- `maa-core`: `Assistant::async_attach_window_by_name` wrapper
- `config`: `Preset::Window` + `window_name` / `focus_for_keys` connection fields
- `run`: dispatch the `Window` preset to the attach API instead of `async_connect`

## Config

```toml
[connection]
preset = "Window"
window_name = "Arknights"   # X11 window title
focus_for_keys = false      # focus the window before sending keys
```

## Verified

On KDE Wayland + XWayland with the Arknights EN PC client (GE-Proton): attach → `ResolutionInfo 1920×1080` → StartUp task drove the login screen (OCR "START" 0.998 → click) via the companion controller.

## Notes

- Requires a MaaCore built with X11 support; without it the attach API returns an error at runtime.
- The game window must stay visible (not minimized); being covered by other windows is fine.

## Summary by Sourcery

在非 Windows 平台上，通过新的 Window 连接预设为 X11 游戏窗口绑定助手的支持。

新功能：
- 引入 Window 连接预设，用于在 Linux 环境中按窗口标题定位 X11 窗口。
- 在 Assistant 上暴露 `async_attach_window_by_name` API，该 API 使用新的 `AsstAsyncAttachWindowByName` 绑定。
- 扩展连接配置，允许为基于窗口的控制指定 `window_name` 和 `focus_for_keys`。

增强：
- 更新 CLI 运行逻辑，在受支持的平台上，将 Window 预设分派到窗口附加 API，而不是基于 ADB 的 `async_connect`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add support for binding the assistant to an X11 game window via a new Window connection preset on non-Windows platforms.

New Features:
- Introduce a Window connection preset that targets an X11 window by title for Linux-based setups.
- Expose an async_attach_window_by_name API on Assistant that uses the new AsstAsyncAttachWindowByName binding.
- Extend connection configuration to allow specifying window_name and focus_for_keys for window-based control.

Enhancements:
- Update CLI run logic to dispatch the Window preset to the window-attach API instead of ADB-based async_connect on supported platforms.

</details>